### PR TITLE
Use Summary-Notification on demand

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -133,6 +133,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.7.0-alpha01'
     implementation 'com.google.android.material:material:1.7.0'
     implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation 'androidx.datastore:datastore-preferences:1.0.0'
 
 
     // Thumbnails

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -106,7 +106,10 @@
         <receiver
             android:name=".BroadcastReceivers.TriggerReciever"
             android:exported="true" />
-
+        <receiver
+            android:name=".BroadcastReceivers.ClearReportBroadcastReciever"
+            android:exported="false">
+        </receiver>
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/ca/pkay/rcloneexplorer/BroadcastReceivers/ClearReportBroadcastReciever.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/BroadcastReceivers/ClearReportBroadcastReciever.kt
@@ -4,6 +4,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import androidx.datastore.preferences.core.edit
+import ca.pkay.rcloneexplorer.notifications.ReportNotifications
 import ca.pkay.rcloneexplorer.notifications.SyncServiceNotifications
 import ca.pkay.rcloneexplorer.notifications.dataStore
 import kotlinx.coroutines.runBlocking
@@ -13,11 +14,20 @@ class ClearReportBroadcastReciever: BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent) {
         val action = intent.action
-        if (action == SyncServiceNotifications.REPORT_SUCCESS_DELETE_INTENT) {
+        if (action == ReportNotifications.REPORT_SUCCESS_DELETE_INTENT) {
             if(context != null){
                 runBlocking {
                     context.dataStore.edit { settings ->
-                        settings[SyncServiceNotifications.NOTIFICATION_CACHE_SUCCESS] = ""
+                        settings[ReportNotifications.NOTIFICATION_CACHE_SUCCESS_PREFERENCE] = ""
+                    }
+                }
+            }
+        }
+        if (action == ReportNotifications.REPORT_FAIL_DELETE_INTENT) {
+            if(context != null){
+                runBlocking {
+                    context.dataStore.edit { settings ->
+                        settings[ReportNotifications.NOTIFICATION_CACHE_FAIL_PREFERENCE] = ""
                     }
                 }
             }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/BroadcastReceivers/ClearReportBroadcastReciever.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/BroadcastReceivers/ClearReportBroadcastReciever.kt
@@ -1,0 +1,26 @@
+package ca.pkay.rcloneexplorer.BroadcastReceivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import androidx.datastore.preferences.core.edit
+import ca.pkay.rcloneexplorer.notifications.SyncServiceNotifications
+import ca.pkay.rcloneexplorer.notifications.dataStore
+import kotlinx.coroutines.runBlocking
+
+
+class ClearReportBroadcastReciever: BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent) {
+        val action = intent.action
+        if (action == SyncServiceNotifications.REPORT_SUCCESS_DELETE_INTENT) {
+            if(context != null){
+                runBlocking {
+                    context.dataStore.edit { settings ->
+                        settings[SyncServiceNotifications.NOTIFICATION_CACHE_SUCCESS] = ""
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Services/SyncService.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Services/SyncService.java
@@ -34,6 +34,7 @@ import ca.pkay.rcloneexplorer.Log2File;
 import ca.pkay.rcloneexplorer.R;
 import ca.pkay.rcloneexplorer.Rclone;
 import ca.pkay.rcloneexplorer.notifications.GenericSyncNotification;
+import ca.pkay.rcloneexplorer.notifications.ReportNotifications;
 import ca.pkay.rcloneexplorer.notifications.StatusObject;
 import ca.pkay.rcloneexplorer.notifications.SyncServiceNotifications;
 import ca.pkay.rcloneexplorer.util.FLog;
@@ -98,6 +99,11 @@ public class SyncService extends IntentService {
                 SyncServiceNotifications.CHANNEL_FAIL_ID,
                 getString(R.string.sync_service_notification_channel_fail_title),
                 R.string.sync_service_notification_channel_fail_description
+        );
+        (new GenericSyncNotification(this)).setNotificationChannel(
+                ReportNotifications.CHANNEL_REPORT_ID,
+                getString(R.string.sync_service_notification_channel_report_title),
+                R.string.sync_service_notification_channel_report_description
         );
         rclone = new Rclone(this);
         log2File = new Log2File(this);
@@ -225,8 +231,8 @@ public class SyncService extends IntentService {
                 if(!errors.isEmpty()) {
                     content += "\n\n\n"+statusObject.getAllErrorMessages();
                 }
-                SyncLog.error(this, getString(R.string.operation_failed), content);
-                notificationManager.showFailedNotification(content, notificationId, internalTask.id);
+                SyncLog.error(this, getString(R.string.operation_failed), title+": "+content);
+                notificationManager.showFailedNotificationOrReport(title, content, notificationId, internalTask.id);
             }else{
                 String message = getResources().getQuantityString(R.plurals.operation_success_description,
                         statusObject.getTotalTransfers(),
@@ -241,6 +247,7 @@ public class SyncService extends IntentService {
                     message += "\n" + getString(R.string.operation_success_description_deletions_prefix, statusObject.getDeletions());
                 }
                 SyncLog.info(this, getString(R.string.operation_success, title), message);
+                //reportManager.showSuccessReport(title, message);
                 notificationManager.showSuccessNotification(title, message, notificationId);
             }
         }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Services/SyncService.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Services/SyncService.java
@@ -247,8 +247,7 @@ public class SyncService extends IntentService {
                     message += "\n" + getString(R.string.operation_success_description_deletions_prefix, statusObject.getDeletions());
                 }
                 SyncLog.info(this, getString(R.string.operation_success, title), message);
-                //reportManager.showSuccessReport(title, message);
-                notificationManager.showSuccessNotification(title, message, notificationId);
+                notificationManager.showSuccessNotificationOrReport(title, message, notificationId, internalTask.id);
             }
         }
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Settings/NotificationsSettingsFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Settings/NotificationsSettingsFragment.java
@@ -4,15 +4,16 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.preference.PreferenceManager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Switch;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import androidx.preference.PreferenceManager;
 
 import ca.pkay.rcloneexplorer.BuildConfig;
 import ca.pkay.rcloneexplorer.R;
@@ -26,6 +27,7 @@ public class NotificationsSettingsFragment extends Fragment {
     private Switch appUpdatesSwitch;
     private View betaAppUpdatesElement;
     private Switch betaAppUpdatesSwitch;
+    private Switch mNotificationReportSwitch;
 
     /**
      * Mandatory empty constructor for the fragment manager to instantiate the
@@ -70,15 +72,18 @@ public class NotificationsSettingsFragment extends Fragment {
         appUpdatesSwitch = view.findViewById(R.id.app_updates_switch);
         betaAppUpdatesElement = view.findViewById(R.id.beta_app_updates);
         betaAppUpdatesSwitch = view.findViewById(R.id.beta_app_updates_switch);
+        mNotificationReportSwitch = view.findViewById(R.id.app_notification_report_switch);
     }
 
     private void setDefaultStates() {
         SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
         boolean appUpdates = sharedPreferences.getBoolean(getString(R.string.pref_key_app_updates), true);
         boolean betaUpdates = sharedPreferences.getBoolean(getString(R.string.pref_key_app_updates_beta), false);
+        boolean notificationReports = sharedPreferences.getBoolean(getString(R.string.pref_key_app_notification_reports), true);
 
         appUpdatesSwitch.setChecked(appUpdates);
         betaAppUpdatesSwitch.setChecked(betaUpdates);
+        mNotificationReportSwitch.setChecked(notificationReports);
 
         String installer = context.getPackageManager().getInstallerPackageName(context.getPackageName());
         boolean isPlayStore = "com.android.vending".equals(installer);
@@ -115,6 +120,9 @@ public class NotificationsSettingsFragment extends Fragment {
             }
         });
         betaAppUpdatesSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> onBetaAppUpdatesClicked(isChecked));
+
+
+        mNotificationReportSwitch.setOnCheckedChangeListener((buttonView, isChecked) -> onNotificationReportsClicked(isChecked));
     }
 
     private void onNotificationsClicked() {
@@ -155,6 +163,13 @@ public class NotificationsSettingsFragment extends Fragment {
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean(getString(R.string.pref_key_app_updates_beta), isChecked);
         editor.putLong(getString(R.string.pref_key_update_last_check), 0L);
+        editor.apply();
+    }
+
+    private void onNotificationReportsClicked(boolean isChecked) {
+        SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putBoolean(getString(R.string.pref_key_app_notification_reports), isChecked);
         editor.apply();
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/ReportNotifications.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/ReportNotifications.kt
@@ -1,0 +1,141 @@
+package ca.pkay.rcloneexplorer.notifications
+
+import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import ca.pkay.rcloneexplorer.BroadcastReceivers.ClearReportBroadcastReciever
+import ca.pkay.rcloneexplorer.BroadcastReceivers.SyncCancelAction
+import ca.pkay.rcloneexplorer.R
+import ca.pkay.rcloneexplorer.Services.SyncService
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+
+
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "notifications")
+
+class ReportNotifications(var mContext: Context) {
+
+    companion object {
+        const val CHANNEL_REPORT_ID = "ca.pkay.rcexplorer.sync_report"
+
+        private const val NOTIFICATION_ID_SUCESS_REPORT = 90
+        private const val NOTIFICATION_ID_FAIL_REPORT = 91
+
+        const val REPORT_SUCCESS_DELETE_INTENT = "REPORT_SUCCESS_DELETE_INTENT"
+        const val REPORT_FAIL_DELETE_INTENT = "REPORT_SUCCESS_DELETE_INTENT"
+
+        val NOTIFICATION_CACHE_SUCCESS_PREFERENCE = stringPreferencesKey("NOTIFICATION_CACHE_SUCCESS")
+        val NOTIFICATION_CACHE_FAIL_PREFERENCE = stringPreferencesKey("NOTIFICATION_CACHE_FAIL")
+    }
+
+    fun showSuccessReport(title: String, line: String) {
+        val content = "$title: $line\n"
+        var successes = 0
+
+
+
+        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
+        runBlocking {
+            mContext.dataStore.edit { settings ->
+                val currentCounterValue: String = (prefMap[NOTIFICATION_CACHE_SUCCESS_PREFERENCE] ?: "") as String
+                if(currentCounterValue.isEmpty()) {
+                    settings[NOTIFICATION_CACHE_SUCCESS_PREFERENCE] = currentCounterValue + content
+                } else {
+                    settings[NOTIFICATION_CACHE_SUCCESS_PREFERENCE] =  content + currentCounterValue
+                }
+            }
+        }
+        val notificationContent: String = content + prefMap[NOTIFICATION_CACHE_SUCCESS_PREFERENCE].toString()
+
+        val builder = NotificationCompat.Builder(mContext, CHANNEL_REPORT_ID)
+            .setSmallIcon(R.drawable.ic_twotone_cloud_24)
+            .setContentTitle(mContext.getString(R.string.operation_report_success_title))
+            .setContentText(mContext.getString(R.string.operation_report_success_short_content, notificationContent.lines().size-1))
+            .setStyle(
+                NotificationCompat.BigTextStyle().bigText(
+                    notificationContent
+                )
+            )
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setDeleteIntent(createDeleteIntent(REPORT_SUCCESS_DELETE_INTENT))
+
+        val notificationManager = NotificationManagerCompat.from(mContext)
+        notificationManager.cancel(NOTIFICATION_ID_SUCESS_REPORT)
+        notificationManager.notify(NOTIFICATION_ID_SUCESS_REPORT, builder.build())
+    }
+
+
+
+    fun addToFailureReport(title: String, line: String) {
+        val content = "$title: $line\n"
+        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
+        runBlocking {
+            mContext.dataStore.edit { settings ->
+                val currentCounterValue: String = (prefMap[NOTIFICATION_CACHE_FAIL_PREFERENCE] ?: "") as String
+                if(currentCounterValue.isEmpty()) {
+                    settings[NOTIFICATION_CACHE_FAIL_PREFERENCE] = currentCounterValue + content
+                } else {
+                    settings[NOTIFICATION_CACHE_FAIL_PREFERENCE] =  content + currentCounterValue
+                }
+            }
+        }
+    }
+
+    fun showFailReport(title: String, line: String) {
+        addToFailureReport(title, line)
+
+        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
+        val notificationContent: String = prefMap[NOTIFICATION_CACHE_FAIL_PREFERENCE].toString()
+
+        val builder = NotificationCompat.Builder(mContext, CHANNEL_REPORT_ID)
+            .setSmallIcon(R.drawable.ic_twotone_cloud_24)
+            .setContentTitle(mContext.getString(R.string.operation_report_fail_title))
+            .setContentText(mContext.getString(R.string.operation_report_fail_short_content, notificationContent.lines().size-1))
+            .setStyle(
+                NotificationCompat.BigTextStyle().bigText(
+                    notificationContent
+                )
+            )
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setDeleteIntent(createDeleteIntent(REPORT_FAIL_DELETE_INTENT))
+
+        val notificationManager = NotificationManagerCompat.from(mContext)
+        notificationManager.cancel(NOTIFICATION_ID_FAIL_REPORT)
+        notificationManager.notify(NOTIFICATION_ID_FAIL_REPORT, builder.build())
+    }
+
+
+    private fun createDeleteIntent(action: String): PendingIntent? {
+        val intent = Intent(mContext, ClearReportBroadcastReciever::class.java)
+        intent.action = action
+        return PendingIntent.getBroadcast(
+            mContext,
+            0,
+            intent,
+            PendingIntent.FLAG_ONE_SHOT or FLAG_IMMUTABLE
+        )
+    }
+
+    fun getFailures(): Int {
+        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
+        val notificationContent = prefMap[NOTIFICATION_CACHE_FAIL_PREFERENCE].toString()
+        return notificationContent.lines().size
+    }
+
+    fun getSucesses(): Int {
+        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
+        val notificationContent = prefMap[NOTIFICATION_CACHE_SUCCESS_PREFERENCE].toString()
+        return notificationContent.lines().size
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
@@ -5,23 +5,11 @@ import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.content.Context
 import android.content.Intent
 import android.os.Build
-import android.util.Log
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
-import androidx.datastore.preferences.preferencesDataStore
-import ca.pkay.rcloneexplorer.BroadcastReceivers.ClearReportBroadcastReciever
 import ca.pkay.rcloneexplorer.BroadcastReceivers.SyncCancelAction
 import ca.pkay.rcloneexplorer.R
 import ca.pkay.rcloneexplorer.Services.SyncService
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.runBlocking
-
-
-val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "notifications")
 
 class SyncServiceNotifications(var mContext: Context) {
 
@@ -31,22 +19,31 @@ class SyncServiceNotifications(var mContext: Context) {
         const val CHANNEL_SUCCESS_ID = "ca.pkay.rcexplorer.sync_service_success"
         const val CHANNEL_FAIL_ID = "ca.pkay.rcexplorer.sync_service_fail"
 
-        @JvmField
-        val REPORT_SUCCESS_DELETE_INTENT = "REPORT_SUCCESS_DELETE_INTENT"
 
         const val PERSISTENT_NOTIFICATION_ID_FOR_SYNC = 162
-        private const val OPERATION_FAILED_NOTIFICATION_ID = 89
-        private const val OPERATION_SUCCESS_NOTIFICATION_ID = 698
 
-
-        val NOTIFICATION_CACHE_SUCCESS = stringPreferencesKey("NOTIFICATION_CACHE_SUCCESS")
     }
+
+    private var reportManager = ReportNotifications(mContext)
 
     private val OPERATION_FAILED_GROUP = "ca.pkay.rcexplorer.OPERATION_FAILED_GROUP"
     private val OPERATION_SUCCESS_GROUP = "ca.pkay.rcexplorer.OPERATION_SUCCESS_GROUP"
 
 
 
+    fun showFailedNotificationOrReport(
+        title: String,
+        content: String?,
+        notificationId: Int,
+        taskid: Long
+    ) {
+        if(reportManager.getFailures()<=1) {
+            showFailedNotification(content, notificationId, taskid)
+            reportManager.addToFailureReport(title, content?: "")
+        } else {
+            reportManager.showFailReport(title, content?: "")
+        }
+    }
     fun showFailedNotification(
         content: String?,
         notificationId: Int,
@@ -76,23 +73,9 @@ class SyncServiceNotifications(var mContext: Context) {
             )
         val notificationManager = NotificationManagerCompat.from(mContext)
         notificationManager.notify(notificationId, builder.build())
-        createSummaryNotificationForFailed()
     }
 
     fun showSuccessNotification(title: String, content: String?, notificationId: Int) {
-
-        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
-        runBlocking {
-            mContext.dataStore.edit { settings ->
-                val currentCounterValue: String = (prefMap[NOTIFICATION_CACHE_SUCCESS] ?: "") as String
-                if(currentCounterValue.isEmpty()) {
-                    settings[NOTIFICATION_CACHE_SUCCESS] = currentCounterValue + content
-                } else {
-                    settings[NOTIFICATION_CACHE_SUCCESS] = currentCounterValue + "\n" +content
-                }
-            }
-        }
-
         val builder = NotificationCompat.Builder(mContext, CHANNEL_SUCCESS_ID)
             .setSmallIcon(R.drawable.ic_twotone_cloud_done_24)
             .setContentTitle(mContext.getString(R.string.operation_success, title))
@@ -106,67 +89,7 @@ class SyncServiceNotifications(var mContext: Context) {
             .setPriority(NotificationCompat.PRIORITY_LOW)
         val notificationManager = NotificationManagerCompat.from(mContext)
         notificationManager.notify(notificationId, builder.build())
-        showSuccessReport()
-        //createSummaryNotificationForSuccess()
     }
-
-
-    fun showSuccessReport() {
-        val prefMap = runBlocking { mContext.dataStore.data.first().asMap() }
-        val te: String = prefMap[NOTIFICATION_CACHE_SUCCESS].toString()
-
-        Log.e("TAAAG", "notify: $te")
-
-        val builder = NotificationCompat.Builder(mContext, CHANNEL_SUCCESS_ID)
-            .setSmallIcon(R.drawable.ic_twotone_cloud_done_24)
-            .setContentTitle(mContext.getString(R.string.operation_success, "Report:"))
-            .setContentText(te)
-            .setStyle(
-                NotificationCompat.BigTextStyle().bigText(
-                    te
-                )
-            )
-            .setGroup(OPERATION_SUCCESS_GROUP)
-            .setPriority(NotificationCompat.PRIORITY_LOW)
-            .setDeleteIntent(createDeleteIntent())
-
-
-        val notificationManager = NotificationManagerCompat.from(mContext)
-        notificationManager.notify(1234567, builder.build())
-        //createSummaryNotificationForSuccess()
-    }
-
-
-
-
-
-    // this will show up if mul
-    fun createSummaryNotificationForFailed() {
-        val summaryNotification = NotificationCompat.Builder(mContext, CHANNEL_ID)
-            .setContentTitle(mContext.getString(R.string.operation_failed)) //set content text to support devices running API level < 24
-            .setContentText(mContext.getString(R.string.operation_failed))
-            .setSmallIcon(R.drawable.ic_twotone_cloud_error_24)
-            .setGroup(OPERATION_FAILED_GROUP)
-            .setGroupSummary(true)
-            .setAutoCancel(true)
-            .build()
-        val notificationManager = NotificationManagerCompat.from(mContext)
-        notificationManager.notify(OPERATION_FAILED_NOTIFICATION_ID, summaryNotification)
-    }
-
-    fun createSummaryNotificationForSuccess() {
-        val summaryNotification = NotificationCompat.Builder(mContext, CHANNEL_ID)
-            .setContentTitle(mContext.getString(R.string.operation_success)) //set content text to support devices running API level < 24
-            .setContentText(mContext.getString(R.string.operation_success))
-            .setSmallIcon(R.drawable.ic_twotone_cloud_done_24)
-            .setGroup(OPERATION_SUCCESS_GROUP)
-            .setGroupSummary(true)
-            .setAutoCancel(true)
-            .build()
-        val notificationManager = NotificationManagerCompat.from(mContext)
-        notificationManager.notify(OPERATION_SUCCESS_NOTIFICATION_ID, summaryNotification)
-    }
-
     fun getPersistentNotification(title: String?): NotificationCompat.Builder {
 
         var flags = 0
@@ -209,17 +132,5 @@ class SyncServiceNotifications(var mContext: Context) {
         )
         val notificationManagerCompat = NotificationManagerCompat.from(mContext)
         notificationManagerCompat.notify(PERSISTENT_NOTIFICATION_ID_FOR_SYNC, builder!!.build())
-    }
-
-
-    private fun createDeleteIntent(): PendingIntent? {
-        val intent = Intent(mContext, ClearReportBroadcastReciever::class.java)
-        intent.action = REPORT_SUCCESS_DELETE_INTENT
-        return PendingIntent.getBroadcast(
-            mContext,
-            0,
-            intent,
-            PendingIntent.FLAG_ONE_SHOT or FLAG_IMMUTABLE
-        )
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
@@ -39,11 +39,14 @@ class SyncServiceNotifications(var mContext: Context) {
     ) {
         if(reportManager.getFailures()<=1) {
             showFailedNotification(content, notificationId, taskid)
+            reportManager.lastFailedNotification(notificationId)
             reportManager.addToFailureReport(title, content?: "")
         } else {
+            reportManager.cancelLastFailedNotification()
             reportManager.showFailReport(title, content?: "")
         }
     }
+
     fun showFailedNotification(
         content: String?,
         notificationId: Int,
@@ -75,6 +78,22 @@ class SyncServiceNotifications(var mContext: Context) {
         notificationManager.notify(notificationId, builder.build())
     }
 
+
+    fun showSuccessNotificationOrReport(
+        title: String,
+        content: String?,
+        notificationId: Int,
+        taskid: Long
+    ) {
+        if(reportManager.getSucesses()<=1) {
+            showSuccessNotification(title, content, notificationId)
+            reportManager.lastSuccededNotification(notificationId)
+            reportManager.addToSuccessReport(title, content?: "")
+        } else {
+            reportManager.cancelLastSuccededNotification()
+            reportManager.showSuccessReport(title, content?: "")
+        }
+    }
     fun showSuccessNotification(title: String, content: String?, notificationId: Int) {
         val builder = NotificationCompat.Builder(mContext, CHANNEL_SUCCESS_ID)
             .setSmallIcon(R.drawable.ic_twotone_cloud_done_24)

--- a/app/src/main/res/layout/settings_fragment_notification.xml
+++ b/app/src/main/res/layout/settings_fragment_notification.xml
@@ -19,6 +19,46 @@
         android:paddingBottom="16dp"
         android:animateLayoutChanges="true">
 
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/notifications_reports"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:focusable="true">
+
+            <TextView
+                android:id="@+id/textView2"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="32dp"
+                android:paddingTop="@dimen/settings_padding_topbottom"
+                android:paddingBottom="@dimen/settings_padding_topbottom"
+                android:text="@string/notification_reports"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/app_notification_report_switch"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <Switch
+                android:id="@+id/app_notification_report_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:id="@+id/app_notification_report_divider"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/settings_divider_size"
+                android:background="@color/dividerColor"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+
+
         <RelativeLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -455,6 +455,10 @@
         <item quantity="other">Successfully synced %2$s in %3$d files.</item>
     </plurals>
     <string name="operation_success_description_deletions_prefix">Also deleted %d files and folders.</string>
+    <string name="operation_report_success_title">Sync-Report Successes</string>
+    <string name="operation_report_success_short_content">%d Tasks succeeded</string>
+    <string name="operation_report_fail_title">Sync-Report Failures</string>
+    <string name="operation_report_fail_short_content">%d Tasks failed</string>
     <string name="pin_to_dektop">Pin to Home</string>
     <string name="title_activity_task">Create a new Task</string>
     <!-- Strings used for fragments for navigation -->
@@ -577,6 +581,8 @@
     <string name="sync_service_notification_channel_fail_title">Sync service fail</string>
     <string name="sync_service_notification_channel_success_description">Notification for successful syncs</string>
     <string name="sync_service_notification_channel_fail_description">Notification for failed syncs</string>
+    <string name="sync_service_notification_channel_report_title">Sync service reports</string>
+    <string name="sync_service_notification_channel_report_description">Notification for sync-reports</string>
     <string name="trigger_type_schedule">Scheduled</string>
     <string name="trigger_type_interval">Interval</string>
     <string name="task_interval">Interval Settings</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@
     <string name="pref_key_wrap_filenames" translatable="false">pref_key_wrap_filenames</string>
     <string name="pref_key_app_updates" translatable="false">pref_key_app_updates</string>
     <string name="pref_key_app_updates_beta" translatable="false">pref_key_app_updates_beta</string>
+    <string name="pref_key_app_notification_reports" translatable="false">pref_key_app_notification_reports</string>
     <string name="pref_key_crash_reports" translatable="false">pref_key_crash_reports</string>
     <string name="pref_key_show_thumbnails" translatable="false">pref_key_show_thumbnails</string>
     <string name="pref_key_thumbnail_size_limit" translatable="false">thumbnail_max_size</string>
@@ -594,4 +595,5 @@
     <string name="trigger_save_notitle">You need to set a title</string>
     <string name="intro_notifications_title">Get Notified!</string>
     <string name="intro_notifications_description">We need to show you notifications when we sync your files, so please grant us access to post notifications. We wont spam you!</string>
+    <string name="notification_reports">Create Reports for Syncs. Replaces singular notifications with a unified one.</string>
 </resources>


### PR DESCRIPTION
If more than one (successful/failed) notification show up in the notification area, only a summary notification is shown.

This will be the default, but can be turned off.

Example:
![image](https://github.com/newhinton/Round-Sync/assets/25279821/2a48458a-3753-4622-82fe-60b606b7c875)
