### PR TITLE
(fix) TriggerService.java a

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Services/TriggerService.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Services/TriggerService.java
@@ -92,23 +92,23 @@ public class TriggerService extends Service {
             SharedPreferences sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
             boolean allowWhileIdle = sharedPreferences.getBoolean(context.getString(R.string.shared_preferences_allow_sync_trigger_while_idle), false);
 
-            if((new PermissionManager(context)).grantedAlarms()) {
-                if (allowWhileIdle) {
-                    am.setExactAndAllowWhileIdle(
-                            AlarmManager.RTC_WAKEUP,
-                            timeToTrigger,
-                            pi
-                    );
+                if((new PermissionManager(context)).grantedAlarms() && (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || am.canScheduleExactAlarms())) {
+                    if (allowWhileIdle) {
+                        am.setExactAndAllowWhileIdle(
+                                AlarmManager.RTC_WAKEUP,
+                                timeToTrigger,
+                                pi
+                        );
+                    } else {
+                        am.setExact(
+                                AlarmManager.RTC_WAKEUP,
+                                timeToTrigger,
+                                pi
+                        );
+                    }
                 } else {
-                    am.setExact(
-                            AlarmManager.RTC_WAKEUP,
-                            timeToTrigger,
-                            pi
-                    );
+                    new AppErrorNotificationManager(context).showNotification();
                 }
-            } else {
-                new AppErrorNotificationManager(context).showNotification();
-            }
         }
     }
 


### PR DESCRIPTION
android api level > 31 requires explicit checking of ability to set alarms, this seemed to be causing a crash on the latest release (v2.2.2) on android 14. I wrote this commit on top of the master branch, (android studio was also complaining about that code), I hope this helps.