### PR TITLE
Option to run all Tasks with only one Trigger

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TriggerActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TriggerActivity.kt
@@ -29,6 +29,7 @@ class TriggerActivity : AppCompatActivity() {
 
     companion object {
         const val ID_EXTRA = "TRIGGER_EDIT_ID"
+        const val ID_ALL_TASKS = -1000L
     }
 
     private lateinit var mTrigger: Trigger
@@ -195,7 +196,11 @@ class TriggerActivity : AppCompatActivity() {
 
         mTargetDropdown.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>?, view: View, pos: Int, id: Long) {
-                mTrigger.triggerTarget = mTaskList[pos].id
+                if (pos == (mTaskList.size)) {
+                    mTrigger.triggerTarget = ID_ALL_TASKS
+                } else {
+                    mTrigger.triggerTarget = mTaskList[pos].id
+                }
             }
 
             override fun onNothingSelected(parent: AdapterView<*>?) {}
@@ -213,10 +218,11 @@ class TriggerActivity : AppCompatActivity() {
      * Set up Task-Target Dropdown
      */
     private fun setUpTargetsDropdown() {
-        val items = arrayOfNulls<String>(this.mTaskList.size)
+        val items = arrayOfNulls<String>(if (this.mTaskList.size == 0) 0 else (this.mTaskList.size + 1))
         for (i in this.mTaskList.indices) {
             items[i] = this.mTaskList[i].title
         }
+        if (this.mTaskList.size > 0) items[this.mTaskList.size] = this.resources.getString(R.string.sync_option_all_tasks_asc)
         val adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, items)
         mTargetDropdown.adapter = adapter
     }
@@ -258,7 +264,9 @@ class TriggerActivity : AppCompatActivity() {
 
         //Todo properly populate the fields
         for (task in mTaskList) {
-            if (task.id == mTrigger.triggerTarget) {
+            if (mTrigger.triggerTarget == ID_ALL_TASKS) {
+                mTargetDropdown.setSelection(mTaskList.size)
+            } else if (task.id == mTrigger.triggerTarget) {
                 mTargetDropdown.setSelection(mTaskList.indexOf(task))
             }
         }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TriggerRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TriggerRecyclerViewAdapter.java
@@ -1,6 +1,7 @@
 package ca.pkay.rcloneexplorer.RecyclerViewAdapters;
 
 
+import static ca.pkay.rcloneexplorer.Activities.TriggerActivity.ID_ALL_TASKS;
 import static ca.pkay.rcloneexplorer.Items.Trigger.TRIGGER_DAY_FRI;
 import static ca.pkay.rcloneexplorer.Items.Trigger.TRIGGER_DAY_MON;
 import static ca.pkay.rcloneexplorer.Items.Trigger.TRIGGER_DAY_SAT;
@@ -82,9 +83,13 @@ public class TriggerRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVie
     public void onBindViewHolder(@NonNull final RecyclerView.ViewHolder holder, final int position) {
         final Trigger selectedTrigger = triggers.get(position);
 
-        Task task = (new DatabaseHandler(context)).getTask(selectedTrigger.getTriggerTarget());
         String targetTaskTitle = "ERR: NOTFOUND";
-        if(task != null){ targetTaskTitle = task.getTitle(); }
+        if (selectedTrigger.getTriggerTarget() == ID_ALL_TASKS) {
+            targetTaskTitle = context.getResources().getString(R.string.sync_title_all_tasks_asc);
+        } else {
+            Task task = (new DatabaseHandler(context)).getTask(selectedTrigger.getTriggerTarget());
+            if (task != null) { targetTaskTitle = task.getTitle(); }
+        }
 
         switch (holder.getItemViewType()) {
             case VIEW_TYPE_SCHEDULE:

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -484,6 +484,8 @@
     <string name="description_sync_direction_copy_toremote">Copy new or modified files from local storage to remote storage. No files are deleted, existing files on the remote may be overwritten.</string>
     <string name="description_sync_direction_copy_tolocal">Copy new or modified files from remote storage to local storage. No files are deleted, existing files on the local storage may be overwritten.</string>
     <string name="description_sync_direction_sync_bidirectional">Make sure local and remote storage have the same files by transferring, downloading, and deleting files as needed to maintain an identical folder structure.</string>
+    <string name="sync_option_all_tasks_asc">All tasks (in alphabetical order)</string>
+    <string name="sync_title_all_tasks_asc">All tasks</string>
     <string name="intro_success">Success!</string>
     <string name="intro_successful_setup">You are now ready to start!</string>
     <string name="intro_write_external_storage_denied">File access permission not granted</string>


### PR DESCRIPTION
I would like to contribute also the following commit to the fantastic Round-Sync:
Option to run all (active) Tasks with only one Trigger (the Tasks will run one by one in alphabetical order).

Some information:
The new dropdown entry "All tasks" gets a Task Id which is negative (I used -1000L) and therefore can easily be recognized as not belonging to any task (as they always have positive Long values). When the SyncManager's queue() finds this Id, all Tasks are fetched from the Database, sorted by title, and enqueued to run one after one. (If one Task finishes with an error, the next Task will still be executed.)

Have a nice weekend.

Best regards
Fabian

![image](https://github.com/newhinton/Round-Sync/assets/20011427/38b972a3-402b-4b33-8ef2-260be7022831)
