### PR TITLE
Adds option to exclude file/folder patterns

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -216,7 +216,13 @@
         <activity
             android:name=".Activities.TriggerActivity"
             android:label="@string/title_activity_trigger"
-            android:theme="@style/AppTheme.NoActionBar" /> <!-- Auto Language Generation -->
+            android:theme="@style/AppTheme.NoActionBar" />
+        <activity
+            android:name=".Activities.FilterActivity"
+            android:label="@string/title_activity_filter"
+            android:theme="@style/AppTheme.NoActionBar" />
+
+        <!-- Auto Language Generation -->
         <service
             android:name="androidx.appcompat.app.AppLocalesMetadataHolderService"
             android:enabled="false"

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/FilterActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/FilterActivity.kt
@@ -1,0 +1,140 @@
+package ca.pkay.rcloneexplorer.Activities
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.Toolbar
+import androidx.core.view.size
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import ca.pkay.rcloneexplorer.Database.DatabaseHandler
+import ca.pkay.rcloneexplorer.Items.Filter
+import ca.pkay.rcloneexplorer.Items.FilterEntry
+import ca.pkay.rcloneexplorer.R
+import ca.pkay.rcloneexplorer.Rclone
+import ca.pkay.rcloneexplorer.RecyclerViewAdapters.FilterEntryRecyclerViewAdapter
+import ca.pkay.rcloneexplorer.util.ActivityHelper
+import com.google.android.material.floatingactionbutton.FloatingActionButton
+import es.dmoral.toasty.Toasty
+import jp.wasabeef.recyclerview.animators.LandingAnimator
+
+class FilterActivity : AppCompatActivity() {
+
+
+    private lateinit var rcloneInstance: Rclone
+    private lateinit var dbHandler: DatabaseHandler
+
+    private lateinit var filterTitle: EditText
+    private lateinit var filterList: RecyclerView
+
+
+    private var existingFilter: Filter? = null
+    private var filters: ArrayList<FilterEntry> = arrayListOf()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        ActivityHelper.applyTheme(this)
+        setContentView(R.layout.activity_filter)
+        val toolbar = findViewById<Toolbar>(R.id.toolbar)
+        setSupportActionBar(toolbar)
+        val actionBar = supportActionBar
+        actionBar?.setDisplayHomeAsUpEnabled(true)
+
+        filterTitle = findViewById(R.id.filter_title_textfield)
+        filterList = findViewById(R.id.filter_filterlist)
+        val newFilterEntry = findViewById<Button>(R.id.filter_add_filterentry_button)
+        newFilterEntry.setOnClickListener {
+            filters.add(FilterEntry(FilterEntry.FILTER_EXCLUDE, ""))
+            filterList.adapter?.notifyItemInserted(filterList.size)
+        }
+
+
+        rcloneInstance = Rclone(this)
+        dbHandler = DatabaseHandler(this)
+        val extras = intent.extras
+        val filterId: Long
+        if (extras != null) {
+            filterId = extras.getLong(ID_EXTRA)
+            if (filterId != 0L) {
+                existingFilter = dbHandler.getFilter(filterId)
+                if (existingFilter == null) {
+                    Toasty.error(
+                            this,
+                            this.resources.getString(R.string.filteractivity_filter_not_found)
+                    ).show()
+                    finish()
+                }
+            }
+        }
+        val fab = findViewById<FloatingActionButton>(R.id.saveButton)
+        fab.setOnClickListener {
+            if (existingFilter == null) {
+                saveFilter()
+            } else {
+                persistFilterChanges()
+            }
+        }
+
+        if(existingFilter != null) {
+            filters = existingFilter!!.getFilters()
+        }
+        filterTitle.setText(existingFilter?.title)
+        prepareFilterList()
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    private fun persistFilterChanges() {
+        val updatedFilter = getFilterValues(existingFilter!!.id)
+        if (updatedFilter != null) {
+            dbHandler.updateFilter(updatedFilter)
+            val resultIntent = Intent()
+            resultIntent.putExtra("filterId", updatedFilter.id)
+            setResult(Activity.RESULT_OK, resultIntent)
+            finish()
+        }
+    }
+
+    private fun saveFilter() {
+        val newFilter = getFilterValues(0)
+        if (newFilter != null) {
+            val filter = dbHandler.createFilter(newFilter)
+            val resultIntent = Intent()
+            resultIntent.putExtra("filterId", filter.id)
+            setResult(Activity.RESULT_OK, resultIntent)
+            finish()
+        }
+    }
+
+    private fun getFilterValues(id: Long): Filter? {
+        val filterToPopulate = Filter(id)
+        filterToPopulate.title = filterTitle.text.toString()
+        filterToPopulate.setFilters(filters)
+        if (filterTitle.text.toString() == "") {
+            Toasty.error(
+                    this.applicationContext,
+                    getString(R.string.filter_data_validation_error_no_title),
+                    Toast.LENGTH_SHORT,
+                    true
+            ).show()
+            return null
+        }
+        return filterToPopulate
+    }
+    private fun prepareFilterList() {
+        val adapter = FilterEntryRecyclerViewAdapter(filters, this)
+        filterList.layoutManager = LinearLayoutManager(this)
+        filterList.itemAnimator = LandingAnimator()
+        filterList.adapter = adapter
+    }
+    companion object {
+        const val ID_EXTRA = "FILTER_EDIT_ID"
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/FilterActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/FilterActivity.kt
@@ -96,7 +96,7 @@ class FilterActivity : AppCompatActivity() {
         if (updatedFilter != null) {
             dbHandler.updateFilter(updatedFilter)
             val resultIntent = Intent()
-            resultIntent.putExtra("filterId", updatedFilter.id)
+            resultIntent.putExtra(SAVED_FILTER_ID_EXTRA, updatedFilter.id)
             setResult(Activity.RESULT_OK, resultIntent)
             finish()
         }
@@ -107,7 +107,7 @@ class FilterActivity : AppCompatActivity() {
         if (newFilter != null) {
             val filter = dbHandler.createFilter(newFilter)
             val resultIntent = Intent()
-            resultIntent.putExtra("filterId", filter.id)
+            resultIntent.putExtra(SAVED_FILTER_ID_EXTRA, filter.id)
             setResult(Activity.RESULT_OK, resultIntent)
             finish()
         }
@@ -136,5 +136,6 @@ class FilterActivity : AppCompatActivity() {
     }
     companion object {
         const val ID_EXTRA = "FILTER_EDIT_ID"
+        const val SAVED_FILTER_ID_EXTRA = "filterId"
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -3,27 +3,41 @@ package ca.pkay.rcloneexplorer.Activities
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
+import android.view.MenuItem
 import android.view.View
-import android.widget.*
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.EditText
+import android.widget.FrameLayout
+import android.widget.ImageButton
+import android.widget.LinearLayout
+import android.widget.Spinner
+import android.widget.Switch
+import android.widget.TextView
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.widget.PopupMenu
 import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import ca.pkay.rcloneexplorer.Database.DatabaseHandler
 import ca.pkay.rcloneexplorer.FilePicker
 import ca.pkay.rcloneexplorer.Fragments.FolderSelectorCallback
 import ca.pkay.rcloneexplorer.Fragments.RemoteFolderPickerFragment
+import ca.pkay.rcloneexplorer.Items.Filter
 import ca.pkay.rcloneexplorer.Items.RemoteItem
 import ca.pkay.rcloneexplorer.Items.SyncDirectionObject
 import ca.pkay.rcloneexplorer.Items.Task
 import ca.pkay.rcloneexplorer.R
 import ca.pkay.rcloneexplorer.Rclone
+import ca.pkay.rcloneexplorer.SpinnerAdapters.FilterSpinnerAdapter
 import ca.pkay.rcloneexplorer.util.ActivityHelper
 import com.google.android.material.floatingactionbutton.FloatingActionButton
 import es.dmoral.toasty.Toasty
 import java.io.UnsupportedEncodingException
 import java.net.URLDecoder
 
-class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
+class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
 
 
     private lateinit var rcloneInstance: Rclone
@@ -34,16 +48,23 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
     private lateinit var localPath: EditText
     private lateinit var remoteDropdown: Spinner
     private lateinit var syncDirection: Spinner
-    private lateinit var exclude: EditText
     private lateinit var fab: FloatingActionButton
 
     private lateinit var switchWifi: Switch
     private lateinit var switchMD5sum: Switch
+
+
+    private lateinit var filterDropdown: Spinner
     private lateinit var switchDeleteExcluded: Switch
+
+
+    private lateinit var filterOptionsButton: ImageButton
 
 
     private var existingTask: Task? = null
     private var remotePathHolder = ""
+    private var selectedFilter: Filter? = null
+
 
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -79,6 +100,12 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
                     Toasty.error(this, "This Remote is not a RCX-Remote.").show()
                 }
             }
+            REQUEST_CODE_FILTER -> if (data != null) {
+                val filterId = data.getLongExtra("filterId", -1)
+                if(filterId >= 0) {
+                    selectFilter(filterId)
+                }
+            }
         }
         fab.visibility = View.VISIBLE
     }
@@ -97,7 +124,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         remoteDropdown = findViewById(R.id.task_remote_spinner)
         syncDirection = findViewById(R.id.task_direction_spinner)
         syncDescription = findViewById(R.id.descriptionSyncDirection)
-        exclude = findViewById(R.id.task_exclude_textfield)
+        filterDropdown = findViewById(R.id.task_filter_spinner)
         switchDeleteExcluded = findViewById(R.id.task_exclude_delete_toggle)
         fab = findViewById(R.id.saveButton)
         switchWifi = findViewById(R.id.task_wifionly)
@@ -130,14 +157,20 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
             }
         }
 
-        findViewById<TextView>(R.id.task_title_textfield).text = existingTask?.title
+        filterOptionsButton = findViewById(R.id.task_edit_filter_options_button)
+        filterOptionsButton.setOnClickListener {
+            val filter = if(filterDropdown.selectedItemPosition > 0 && filterDropdown.selectedItemPosition < filterDropdown.count) filterItems[filterDropdown.selectedItemPosition - 1] else null
+            showFilterMenu(filterOptionsButton, filter)
+        }
+
+        findViewById<TextView>(R.id.filter_title_textfield).text = existingTask?.title
         switchWifi.isChecked = existingTask?.wifionly ?: false
         switchMD5sum.isChecked = existingTask?.md5sum ?: false
         switchDeleteExcluded.isChecked = existingTask?.deleteExcluded ?: false
-        exclude.setText(existingTask?.exclude ?: "")
         prepareSyncDirectionDropdown()
         prepareLocal()
         prepareRemote()
+        prepareFilterDropdown()
     }
 
     private val remoteItems: Array<String?>
@@ -147,6 +180,10 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
                 remotes[i] = rcloneInstance.remotes[i].name
             }
             return remotes
+        }
+    private val filterItems: List<Filter>
+        get() {
+            return dbHandler.allFilters
         }
 
 
@@ -173,7 +210,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
 
     private fun getTaskValues(id: Long): Task? {
         val taskToPopulate = Task(id)
-        taskToPopulate.title = findViewById<EditText>(R.id.task_title_textfield).text.toString()
+        taskToPopulate.title = findViewById<EditText>(R.id.filter_title_textfield).text.toString()
         val remotename = remoteDropdown.selectedItem.toString()
         taskToPopulate.remoteId = remotename
         val direction = syncDirection.selectedItemPosition + 1
@@ -185,11 +222,11 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         taskToPopulate.remotePath = remotePath.text.toString()
         taskToPopulate.localPath = localPath.text.toString()
         taskToPopulate.direction = direction
-        taskToPopulate.exclude = exclude.text.toString()
 
         taskToPopulate.wifionly = switchWifi.isChecked
         taskToPopulate.md5sum = switchMD5sum.isChecked
         taskToPopulate.deleteExcluded = switchDeleteExcluded.isChecked
+        taskToPopulate.filterId = if(filterDropdown.selectedItemPosition == 0) null else filterItems[filterDropdown.selectedItemPosition - 1].id
 
         // Verify if data is completed
         if (localPath.text.toString() == "") {
@@ -226,6 +263,15 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         remotePathHolder = path
         remotePath.setText(remotePathHolder)
         fab.visibility = View.VISIBLE
+    }
+    private fun selectFilter(filterId: Long) {
+        prepareFilterDropdown()
+
+        for ((i, filter) in filterItems.withIndex()) {
+            if (filter.id == filterId) {
+                filterDropdown.setSelection(i + 1)
+            }
+        }
     }
 
     private fun prepareLocal() {
@@ -278,6 +324,88 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
             }
         }
     }
+    private fun prepareFilterDropdown() {
+        val filterList = filterItems.toMutableList()
+
+        if(filterList.isEmpty()) {
+            val createNewButton = Button(this)
+            createNewButton.text = getString(R.string.add_filter)
+            createNewButton.setOnClickListener {
+                openFilterActivity()
+            }
+            val layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+            )
+            createNewButton.layoutParams = layoutParams
+
+            val spinnerPlaceholder = findViewById<FrameLayout>(R.id.task_edit_filter_holder)
+            filterDropdown.visibility = View.INVISIBLE
+            spinnerPlaceholder.addView(createNewButton)
+        }
+        else {
+            val titles = mutableListOf<String?>().apply {
+                add(getString(R.string.task_edit_filter_nofilter))
+                addAll(filterList.map { it.title })
+            }
+
+            val adapter = FilterSpinnerAdapter(this, android.R.layout.simple_spinner_dropdown_item, titles)
+            filterDropdown.adapter = adapter
+
+            if (existingTask != null) {
+                for ((i, filter) in filterList.withIndex()) {
+                    if (filter.id == existingTask!!.filterId) {
+                        filterDropdown.setSelection(i + 1)
+                    }
+                }
+            }
+
+            filterDropdown.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parentView: AdapterView<*>?, selectedItemView: View, position: Int, id: Long) {
+                    selectedFilter = if (position > 0 && position < titles.size) filterItems[position - 1] else null
+                }
+                override fun onNothingSelected(parentView: AdapterView<*>?) {}
+            }
+        }
+    }
+
+    private fun showFilterMenu(view: View, filter: Filter?) {
+        val popupMenu = PopupMenu(this, view)
+        popupMenu.menuInflater.inflate(R.menu.filter_item_menu, popupMenu.menu)
+        val menu = popupMenu.menu
+        for (i in 0 until menu.size()) {
+            val menuItem = menu.getItem(i)
+            if (menuItem.itemId == R.id.action_edit_filter ||
+                    menuItem.itemId == R.id.action_delete_filter) {
+                menuItem.isVisible = filter != null
+            }
+        }
+        popupMenu.setOnMenuItemClickListener { item: MenuItem ->
+            when (item.itemId) {
+                R.id.action_create_new_filter -> {
+                    openFilterActivity()
+                }
+                R.id.action_edit_filter -> {
+                    openFilterActivity(filter)
+                }
+                R.id.action_delete_filter -> {
+                    dbHandler.deleteFilter(filter!!.id)
+                    filterDropdown.setSelection(0)
+                    prepareFilterDropdown()
+                }
+                else -> return@setOnMenuItemClickListener false
+            }
+            true
+        }
+        popupMenu.show()
+    }
+    private fun openFilterActivity(filter: Filter? = null) {
+        val intent = Intent(this, FilterActivity::class.java)
+        if(filter != null) {
+            intent.putExtra(FilterActivity.ID_EXTRA, filter.id)
+        }
+        startActivityForResult(intent, REQUEST_CODE_FILTER)
+    }
 
     private fun prepareSyncDirectionDropdown() {
         val options = SyncDirectionObject.getOptionsArray(this)
@@ -320,6 +448,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         const val ID_EXTRA = "TASK_EDIT_ID"
         const val REQUEST_CODE_FP_LOCAL = 500
         const val REQUEST_CODE_FP_REMOTE = 444
+        const val REQUEST_CODE_FILTER = 333
 
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -55,6 +55,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
 
 
     private lateinit var filterDropdown: Spinner
+    private lateinit var createNewFilterButton: Button
     private lateinit var switchDeleteExcluded: Switch
 
 
@@ -161,6 +162,10 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
         filterOptionsButton.setOnClickListener {
             val filter = if(filterDropdown.selectedItemPosition > 0 && filterDropdown.selectedItemPosition < filterDropdown.count) filterItems[filterDropdown.selectedItemPosition - 1] else null
             showFilterMenu(filterOptionsButton, filter)
+        }
+        createNewFilterButton = findViewById<Button>(R.id.task_edit_filter_add_button)
+        createNewFilterButton.setOnClickListener {
+            openFilterActivity()
         }
 
         findViewById<TextView>(R.id.filter_title_textfield).text = existingTask?.title
@@ -328,20 +333,8 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
         val filterList = filterItems.toMutableList()
 
         if(filterList.isEmpty()) {
-            val createNewButton = Button(this)
-            createNewButton.text = getString(R.string.add_filter)
-            createNewButton.setOnClickListener {
-                openFilterActivity()
-            }
-            val layoutParams = LinearLayout.LayoutParams(
-                    LinearLayout.LayoutParams.MATCH_PARENT,
-                    LinearLayout.LayoutParams.WRAP_CONTENT
-            )
-            createNewButton.layoutParams = layoutParams
-
-            val spinnerPlaceholder = findViewById<FrameLayout>(R.id.task_edit_filter_holder)
+            createNewFilterButton.visibility = View.VISIBLE
             filterDropdown.visibility = View.INVISIBLE
-            spinnerPlaceholder.addView(createNewButton)
         }
         else {
             val titles = mutableListOf<String?>().apply {
@@ -351,6 +344,8 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
 
             val adapter = FilterSpinnerAdapter(this, android.R.layout.simple_spinner_dropdown_item, titles)
             filterDropdown.adapter = adapter
+            createNewFilterButton.visibility = View.INVISIBLE
+            filterDropdown.visibility = View.VISIBLE
 
             if (existingTask != null) {
                 for ((i, filter) in filterList.withIndex()) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -34,10 +34,12 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
     private lateinit var localPath: EditText
     private lateinit var remoteDropdown: Spinner
     private lateinit var syncDirection: Spinner
+    private lateinit var exclude: EditText
     private lateinit var fab: FloatingActionButton
 
     private lateinit var switchWifi: Switch
     private lateinit var switchMD5sum: Switch
+    private lateinit var switchDeleteExcluded: Switch
 
 
     private var existingTask: Task? = null
@@ -95,6 +97,8 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         remoteDropdown = findViewById(R.id.task_remote_spinner)
         syncDirection = findViewById(R.id.task_direction_spinner)
         syncDescription = findViewById(R.id.descriptionSyncDirection)
+        exclude = findViewById(R.id.task_exclude_textfield)
+        switchDeleteExcluded = findViewById(R.id.task_exclude_delete_toggle)
         fab = findViewById(R.id.saveButton)
         switchWifi = findViewById(R.id.task_wifionly)
         switchMD5sum = findViewById(R.id.task_md5sum)
@@ -129,10 +133,11 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         findViewById<TextView>(R.id.task_title_textfield).text = existingTask?.title
         switchWifi.isChecked = existingTask?.wifionly ?: false
         switchMD5sum.isChecked = existingTask?.md5sum ?: false
+        switchDeleteExcluded.isChecked = existingTask?.deleteExcluded ?: false
+        exclude.setText(existingTask?.exclude ?: "")
         prepareSyncDirectionDropdown()
         prepareLocal()
         prepareRemote()
-
     }
 
     private val remoteItems: Array<String?>
@@ -180,9 +185,11 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback {
         taskToPopulate.remotePath = remotePath.text.toString()
         taskToPopulate.localPath = localPath.text.toString()
         taskToPopulate.direction = direction
+        taskToPopulate.exclude = exclude.text.toString()
 
         taskToPopulate.wifionly = switchWifi.isChecked
         taskToPopulate.md5sum = switchMD5sum.isChecked
+        taskToPopulate.deleteExcluded = switchDeleteExcluded.isChecked
 
         // Verify if data is completed
         if (localPath.text.toString() == "") {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -9,9 +9,7 @@ import android.widget.AdapterView
 import android.widget.ArrayAdapter
 import android.widget.Button
 import android.widget.EditText
-import android.widget.FrameLayout
 import android.widget.ImageButton
-import android.widget.LinearLayout
 import android.widget.Spinner
 import android.widget.Switch
 import android.widget.TextView
@@ -168,7 +166,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
             openFilterActivity()
         }
 
-        findViewById<TextView>(R.id.filter_title_textfield).text = existingTask?.title
+        findViewById<TextView>(R.id.task_title_textfield).text = existingTask?.title
         switchWifi.isChecked = existingTask?.wifionly ?: false
         switchMD5sum.isChecked = existingTask?.md5sum ?: false
         switchDeleteExcluded.isChecked = existingTask?.deleteExcluded ?: false
@@ -215,7 +213,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
 
     private fun getTaskValues(id: Long): Task? {
         val taskToPopulate = Task(id)
-        taskToPopulate.title = findViewById<EditText>(R.id.filter_title_textfield).text.toString()
+        taskToPopulate.title = findViewById<EditText>(R.id.task_title_textfield).text.toString()
         val remotename = remoteDropdown.selectedItem.toString()
         taskToPopulate.remoteId = remotename
         val direction = syncDirection.selectedItemPosition + 1

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/TaskActivity.kt
@@ -102,7 +102,7 @@ class TaskActivity : AppCompatActivity(), FolderSelectorCallback{
                 }
             }
             REQUEST_CODE_FILTER -> if (data != null) {
-                val filterId = data.getLongExtra("filterId", -1)
+                val filterId = data.getLongExtra(FilterActivity.SAVED_FILTER_ID_EXTRA, -1)
                 if(filterId >= 0) {
                     selectFilter(filterId)
                 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseHandler.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseHandler.kt
@@ -9,8 +9,10 @@ import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.DATABASE_NAME
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.DATABASE_VERSION
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_CREATE_TABLES_TASKS
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_CREATE_TABLE_TRIGGER
+import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_MD5
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_WIFI
+import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_EXCLUDE
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TRIGGER_ADD_TYPE
 import ca.pkay.rcloneexplorer.Items.Task
 import ca.pkay.rcloneexplorer.Items.Trigger
@@ -25,6 +27,8 @@ class DatabaseHandler(context: Context?) :
         sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_MD5)
         sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_WIFI)
         sqLiteDatabase.execSQL(SQL_UPDATE_TRIGGER_ADD_TYPE)
+        sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_EXCLUDE)
+        sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED)
     }
 
     override fun onUpgrade(sqLiteDatabase: SQLiteDatabase, oldVersion: Int, newVersion: Int) {
@@ -37,6 +41,10 @@ class DatabaseHandler(context: Context?) :
         }
         if (oldVersion < 4) {
             sqLiteDatabase.execSQL(SQL_UPDATE_TRIGGER_ADD_TYPE)
+        }
+        if (oldVersion < 5) {
+            sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_EXCLUDE)
+            sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED)
         }
     }
 
@@ -118,7 +126,9 @@ class DatabaseHandler(context: Context?) :
             Task.COLUMN_NAME_LOCAL_PATH,
             Task.COLUMN_NAME_SYNC_DIRECTION,
             Task.COLUMN_NAME_MD5SUM,
-            Task.COLUMN_NAME_WIFI_ONLY
+            Task.COLUMN_NAME_WIFI_ONLY,
+            Task.COLUMN_NAME_EXCLUDE,
+            Task.COLUMN_NAME_DELETE_EXCLUDED
         )
 
     private fun taskFromCursor(cursor: Cursor): Task {
@@ -131,6 +141,8 @@ class DatabaseHandler(context: Context?) :
         task.direction = cursor.getInt(6)
         task.md5sum = getBoolean(cursor, 7)
         task.wifionly = getBoolean(cursor, 8)
+        task.exclude = cursor.getString(9)
+        task.deleteExcluded = getBoolean(cursor, 10)
         return task
     }
 
@@ -156,6 +168,8 @@ class DatabaseHandler(context: Context?) :
         values.put(Task.COLUMN_NAME_REMOTE_ID, task.remoteId)
         values.put(Task.COLUMN_NAME_REMOTE_PATH, task.remotePath)
         values.put(Task.COLUMN_NAME_REMOTE_TYPE, task.remoteType)
+        values.put(Task.COLUMN_NAME_EXCLUDE, task.exclude)
+        values.put(Task.COLUMN_NAME_DELETE_EXCLUDED, task.deleteExcluded)
         values.put(Task.COLUMN_NAME_SYNC_DIRECTION, task.direction)
         values.put(Task.COLUMN_NAME_MD5SUM, task.md5sum)
         values.put(Task.COLUMN_NAME_WIFI_ONLY, task.wifionly)

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseHandler.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseHandler.kt
@@ -101,9 +101,9 @@ class DatabaseHandler(context: Context?) :
         } else results[0]
     }
 
-    fun createTask(taskToStore: Task): Task {
+    fun createTask(taskToStore: Task, withId: Boolean = false): Task {
         val db = writableDatabase
-        val newRowId = db.insert(Task.TABLE_NAME, null, getTaskContentValues(taskToStore))
+        val newRowId = db.insert(Task.TABLE_NAME, null, if(withId) getTaskContentValuesWithID(taskToStore) else getTaskContentValues(taskToStore))
         db.close()
         taskToStore.id = newRowId
         return taskToStore
@@ -231,9 +231,9 @@ class DatabaseHandler(context: Context?) :
         } else results[0]
     }
 
-    fun createTrigger(triggerToStore: Trigger): Trigger {
+    fun createTrigger(triggerToStore: Trigger, withId: Boolean = false): Trigger {
         val db = writableDatabase
-        val newRowId = db.insert(Trigger.TABLE_NAME, null, getTriggerContentValues(triggerToStore))
+        val newRowId = db.insert(Trigger.TABLE_NAME, null, if(withId) getTriggerContentValuesWithID(triggerToStore) else getTriggerContentValues(triggerToStore))
         db.close()
         triggerToStore.id = newRowId
         return triggerToStore
@@ -267,6 +267,9 @@ class DatabaseHandler(context: Context?) :
 
     private fun getTriggerContentValues(t: Trigger): ContentValues {
         val values = ContentValues()
+        if(t.id != Trigger.TRIGGER_ID_DOESNTEXIST) {
+            values.put(Trigger.COLUMN_NAME_ID, t.id)
+        }
         values.put(Trigger.COLUMN_NAME_TITLE, t.title)
         values.put(Trigger.COLUMN_NAME_ENABLED, t.isEnabled)
         values.put(Trigger.COLUMN_NAME_TIME, t.time)
@@ -350,9 +353,9 @@ class DatabaseHandler(context: Context?) :
         } else results[0]
     }
 
-    fun createFilter(filterToStore: Filter): Filter {
+    fun createFilter(filterToStore: Filter, withId: Boolean = false): Filter {
         val db = writableDatabase
-        val newRowId = db.insert(Filter.TABLE_NAME, null, getFilterContentValues(filterToStore))
+        val newRowId = db.insert(Filter.TABLE_NAME, null, if(withId) getFilterContentValuesWithID(filterToStore) else getFilterContentValues(filterToStore))
         db.close()
         filterToStore.id = newRowId
         return filterToStore

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseHandler.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseHandler.kt
@@ -8,12 +8,14 @@ import android.database.sqlite.SQLiteOpenHelper
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.DATABASE_NAME
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.DATABASE_VERSION
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_CREATE_TABLES_TASKS
+import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_CREATE_TABLE_FILTERS
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_CREATE_TABLE_TRIGGER
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_MD5
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_WIFI
-import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_EXCLUDE
+import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TASK_ADD_FILTER_ID
 import ca.pkay.rcloneexplorer.Database.DatabaseInfo.Companion.SQL_UPDATE_TRIGGER_ADD_TYPE
+import ca.pkay.rcloneexplorer.Items.Filter
 import ca.pkay.rcloneexplorer.Items.Task
 import ca.pkay.rcloneexplorer.Items.Trigger
 import java.util.ArrayList
@@ -24,10 +26,11 @@ class DatabaseHandler(context: Context?) :
     override fun onCreate(sqLiteDatabase: SQLiteDatabase) {
         sqLiteDatabase.execSQL(SQL_CREATE_TABLES_TASKS)
         sqLiteDatabase.execSQL(SQL_CREATE_TABLE_TRIGGER)
+        sqLiteDatabase.execSQL(SQL_CREATE_TABLE_FILTERS)
         sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_MD5)
         sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_WIFI)
         sqLiteDatabase.execSQL(SQL_UPDATE_TRIGGER_ADD_TYPE)
-        sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_EXCLUDE)
+        sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_FILTER_ID)
         sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED)
     }
 
@@ -43,7 +46,8 @@ class DatabaseHandler(context: Context?) :
             sqLiteDatabase.execSQL(SQL_UPDATE_TRIGGER_ADD_TYPE)
         }
         if (oldVersion < 5) {
-            sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_EXCLUDE)
+            sqLiteDatabase.execSQL(SQL_CREATE_TABLE_FILTERS)
+            sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_FILTER_ID)
             sqLiteDatabase.execSQL(SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED)
         }
     }
@@ -127,7 +131,7 @@ class DatabaseHandler(context: Context?) :
             Task.COLUMN_NAME_SYNC_DIRECTION,
             Task.COLUMN_NAME_MD5SUM,
             Task.COLUMN_NAME_WIFI_ONLY,
-            Task.COLUMN_NAME_EXCLUDE,
+            Task.COLUMN_NAME_FILTER_ID,
             Task.COLUMN_NAME_DELETE_EXCLUDED
         )
 
@@ -141,7 +145,7 @@ class DatabaseHandler(context: Context?) :
         task.direction = cursor.getInt(6)
         task.md5sum = getBoolean(cursor, 7)
         task.wifionly = getBoolean(cursor, 8)
-        task.exclude = cursor.getString(9)
+        task.filterId = cursor.getLong(9)
         task.deleteExcluded = getBoolean(cursor, 10)
         return task
     }
@@ -168,11 +172,11 @@ class DatabaseHandler(context: Context?) :
         values.put(Task.COLUMN_NAME_REMOTE_ID, task.remoteId)
         values.put(Task.COLUMN_NAME_REMOTE_PATH, task.remotePath)
         values.put(Task.COLUMN_NAME_REMOTE_TYPE, task.remoteType)
-        values.put(Task.COLUMN_NAME_EXCLUDE, task.exclude)
-        values.put(Task.COLUMN_NAME_DELETE_EXCLUDED, task.deleteExcluded)
         values.put(Task.COLUMN_NAME_SYNC_DIRECTION, task.direction)
         values.put(Task.COLUMN_NAME_MD5SUM, task.md5sum)
         values.put(Task.COLUMN_NAME_WIFI_ONLY, task.wifionly)
+        values.put(Task.COLUMN_NAME_FILTER_ID, task.filterId)
+        values.put(Task.COLUMN_NAME_DELETE_EXCLUDED, task.deleteExcluded)
         return values
     }
 
@@ -184,13 +188,13 @@ class DatabaseHandler(context: Context?) :
             val selectionArgs = arrayOf<String>()
             val sortOrder = Trigger.COLUMN_NAME_ID + " ASC"
             val cursor = db.query(
-                Trigger.TABLE_NAME,
-                projection,
-                selection,
-                selectionArgs,
-                null,
-                null,
-                sortOrder
+                    Trigger.TABLE_NAME,
+                    projection,
+                    selection,
+                    selectionArgs,
+                    null,
+                    null,
+                    sortOrder
             )
             val results: MutableList<Trigger> = ArrayList()
             while (cursor.moveToNext()) {
@@ -208,13 +212,13 @@ class DatabaseHandler(context: Context?) :
         val selectionArgs = arrayOf(id.toString())
         val sortOrder = Trigger.COLUMN_NAME_ID + " ASC"
         val cursor = db.query(
-            Trigger.TABLE_NAME,
-            projection,
-            selection,
-            selectionArgs,
-            null,
-            null,
-            sortOrder
+                Trigger.TABLE_NAME,
+                projection,
+                selection,
+                selectionArgs,
+                null,
+                null,
+                sortOrder
         )
         val results: MutableList<Trigger> = ArrayList()
         while (cursor.moveToNext()) {
@@ -238,10 +242,10 @@ class DatabaseHandler(context: Context?) :
     fun updateTrigger(triggerToUpdate: Trigger) {
         val db = writableDatabase
         db.update(
-            Trigger.TABLE_NAME,
-            getTriggerContentValuesWithID(triggerToUpdate),
-            Trigger.COLUMN_NAME_ID + " = ?",
-            arrayOf(triggerToUpdate.id.toString())
+                Trigger.TABLE_NAME,
+                getTriggerContentValuesWithID(triggerToUpdate),
+                Trigger.COLUMN_NAME_ID + " = ?",
+                arrayOf(triggerToUpdate.id.toString())
         )
         db.close()
     }
@@ -274,13 +278,13 @@ class DatabaseHandler(context: Context?) :
 
     private val triggerProjection: Array<String>
         private get() = arrayOf(
-            Trigger.COLUMN_NAME_ID,
-            Trigger.COLUMN_NAME_TITLE,
-            Trigger.COLUMN_NAME_ENABLED,
-            Trigger.COLUMN_NAME_TIME,
-            Trigger.COLUMN_NAME_WEEKDAY,
-            Trigger.COLUMN_NAME_TARGET,
-            Trigger.COLUMN_NAME_TYPE
+                Trigger.COLUMN_NAME_ID,
+                Trigger.COLUMN_NAME_TITLE,
+                Trigger.COLUMN_NAME_ENABLED,
+                Trigger.COLUMN_NAME_TIME,
+                Trigger.COLUMN_NAME_WEEKDAY,
+                Trigger.COLUMN_NAME_TARGET,
+                Trigger.COLUMN_NAME_TYPE
         )
 
     private fun triggerFromCursor(cursor: Cursor): Trigger {
@@ -295,12 +299,121 @@ class DatabaseHandler(context: Context?) :
         return trigger
     }
 
+    val allFilters: List<Filter>
+        get() {
+            val db = readableDatabase
+            val projection = filterProjection
+            val selection = ""
+            val selectionArgs = arrayOf<String>()
+            val sortOrder = Filter.COLUMN_NAME_ID + " ASC"
+            val cursor = db.query(
+                    Filter.TABLE_NAME,
+                    projection,
+                    selection,
+                    selectionArgs,
+                    null,
+                    null,
+                    sortOrder
+            )
+            val results: MutableList<Filter> = ArrayList()
+            while (cursor.moveToNext()) {
+                results.add(filterFromCursor(cursor))
+            }
+            cursor.close()
+            db.close()
+            return results
+        }
+
+    fun getFilter(id: Long): Filter? {
+        val db = readableDatabase
+        val projection = filterProjection
+        val selection = Filter.COLUMN_NAME_ID + " LIKE ?"
+        val selectionArgs = arrayOf(id.toString())
+        val sortOrder = Filter.COLUMN_NAME_ID + " ASC"
+        val cursor = db.query(
+                Filter.TABLE_NAME,
+                projection,
+                selection,
+                selectionArgs,
+                null,
+                null,
+                sortOrder
+        )
+        val results: MutableList<Filter> = ArrayList()
+        while (cursor.moveToNext()) {
+            results.add(filterFromCursor(cursor))
+        }
+        cursor.close()
+        db.close()
+        return if (results.size == 0) {
+            null
+        } else results[0]
+    }
+
+    fun createFilter(filterToStore: Filter): Filter {
+        val db = writableDatabase
+        val newRowId = db.insert(Filter.TABLE_NAME, null, getFilterContentValues(filterToStore))
+        db.close()
+        filterToStore.id = newRowId
+        return filterToStore
+    }
+
+    fun updateFilter(filterToUpdate: Filter) {
+        val db = writableDatabase
+        db.update(
+                Filter.TABLE_NAME,
+                getFilterContentValuesWithID(filterToUpdate),
+                Filter.COLUMN_NAME_ID + " = ?",
+                arrayOf(filterToUpdate.id.toString())
+        )
+        db.close()
+    }
+
+    fun deleteFilter(id: Long): Int {
+        val db = writableDatabase
+        val selection = Filter.COLUMN_NAME_ID + " LIKE ?"
+        val selectionArgs = arrayOf(id.toString())
+        val retcode = db.delete(Filter.TABLE_NAME, selection, selectionArgs)
+        db.close()
+        return retcode
+    }
+
+    private fun getFilterContentValuesWithID(t: Filter): ContentValues {
+        val values = getFilterContentValues(t)
+        values.put(Filter.COLUMN_NAME_ID, t.id)
+        return values
+    }
+
+    private fun getFilterContentValues(t: Filter): ContentValues {
+        val values = ContentValues()
+        values.put(Filter.COLUMN_NAME_TITLE, t.title)
+        values.put(Filter.COLUMN_NAME_FILTERS, t.getFiltersRaw())
+        return values
+    }
+
+    private val filterProjection: Array<String>
+        private get() = arrayOf(
+                Filter.COLUMN_NAME_ID,
+                Filter.COLUMN_NAME_TITLE,
+                Filter.COLUMN_NAME_FILTERS,
+        )
+
+    private fun filterFromCursor(cursor: Cursor): Filter {
+        val filter = Filter(cursor.getLong(0))
+        filter.title = cursor.getString(1)
+        filter.setFiltersRaw(cursor.getString(2))
+        return filter
+    }
+
     fun deleteEveryting() {
         for (trigger in allTrigger) {
             deleteTrigger(trigger.id)
         }
         for (task in allTasks) {
             deleteTask(task.id)
+        }
+        for (filter in allFilters) {
+            deleteFilter(filter.id)
         }
     }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseInfo.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseInfo.kt
@@ -1,5 +1,6 @@
 package ca.pkay.rcloneexplorer.Database
 
+import ca.pkay.rcloneexplorer.Items.Filter
 import ca.pkay.rcloneexplorer.Items.Task
 import ca.pkay.rcloneexplorer.Items.Trigger
 
@@ -29,11 +30,16 @@ class DatabaseInfo {
                 Trigger.COLUMN_NAME_WEEKDAY + " INTEGER," +
                 Trigger.COLUMN_NAME_TARGET + " INTEGER)"
 
+        val SQL_CREATE_TABLE_FILTERS = "CREATE TABLE " + Filter.TABLE_NAME + " (" +
+                Filter.COLUMN_NAME_ID + " INTEGER PRIMARY KEY," +
+                Filter.COLUMN_NAME_TITLE + " TEXT," +
+                Filter.COLUMN_NAME_FILTERS + " TEXT)"
+
 
         val SQL_UPDATE_TASK_ADD_MD5 = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_MD5SUM} INTEGER"
         val SQL_UPDATE_TASK_ADD_WIFI = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_WIFI_ONLY} INTEGER"
         val SQL_UPDATE_TRIGGER_ADD_TYPE = "ALTER TABLE ${Trigger.TABLE_NAME} ADD COLUMN ${Trigger.COLUMN_NAME_TYPE} INTEGER DEFAULT ${Trigger.TRIGGER_TYPE_SCHEDULE}"
-        val SQL_UPDATE_TASK_ADD_EXCLUDE = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_EXCLUDE} TEXT"
+        val SQL_UPDATE_TASK_ADD_FILTER_ID = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_FILTER_ID} INTEGER REFERENCES ${Filter.TABLE_NAME}(${Filter.COLUMN_NAME_ID}) ON DELETE SET NULL"
         val SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_DELETE_EXCLUDED} INTEGER"
 
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseInfo.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/DatabaseInfo.kt
@@ -8,7 +8,7 @@ class DatabaseInfo {
     companion object {
 
         // If you change the database schema, you must increment the database version.
-        const val DATABASE_VERSION = 4
+        const val DATABASE_VERSION = 5
         const val DATABASE_NAME = "rcloneExplorer.db"
 
 
@@ -33,6 +33,8 @@ class DatabaseInfo {
         val SQL_UPDATE_TASK_ADD_MD5 = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_MD5SUM} INTEGER"
         val SQL_UPDATE_TASK_ADD_WIFI = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_WIFI_ONLY} INTEGER"
         val SQL_UPDATE_TRIGGER_ADD_TYPE = "ALTER TABLE ${Trigger.TABLE_NAME} ADD COLUMN ${Trigger.COLUMN_NAME_TYPE} INTEGER DEFAULT ${Trigger.TRIGGER_TYPE_SCHEDULE}"
+        val SQL_UPDATE_TASK_ADD_EXCLUDE = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_EXCLUDE} TEXT"
+        val SQL_UPDATE_TASK_ADD_DELETE_EXCLUDED = "ALTER TABLE ${Task.TABLE_NAME} ADD COLUMN ${Task.COLUMN_NAME_DELETE_EXCLUDED} INTEGER"
 
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Exporter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Exporter.java
@@ -7,6 +7,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 import ca.pkay.rcloneexplorer.Database.DatabaseHandler;
+import ca.pkay.rcloneexplorer.Items.Filter;
 import ca.pkay.rcloneexplorer.Items.Task;
 import ca.pkay.rcloneexplorer.Items.Trigger;
 
@@ -28,6 +29,14 @@ public class Exporter {
             triggers.put(trigger.asJSON());
         }
         main.put("trigger", triggers);
+
+        JSONArray filters = new JSONArray();
+        for(Filter filter : dbHandler.getAllFilters()){
+            filters.put(filter.asJSON());
+        }
+        main.put("filters", filters);
+
+
         return main.toString();
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Importer.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Importer.java
@@ -9,6 +9,7 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 
 import ca.pkay.rcloneexplorer.Database.DatabaseHandler;
+import ca.pkay.rcloneexplorer.Items.Filter;
 import ca.pkay.rcloneexplorer.Items.Task;
 import ca.pkay.rcloneexplorer.Items.Trigger;
 
@@ -19,10 +20,13 @@ public class Importer {
         DatabaseHandler dbHandler = new DatabaseHandler(context);
         dbHandler.deleteEveryting();
         for(Trigger trigger : createTriggerlist(json)){
-            dbHandler.createTrigger(trigger);
+            dbHandler.createTrigger(trigger, true);
+        }
+        for(Filter filter : createFilterList(json)){
+            dbHandler.createFilter(filter, true);
         }
         for(Task task : createTasklist(json)){
-            dbHandler.createTask(task);
+            dbHandler.createTask(task, true);
         }
     }
 
@@ -44,6 +48,16 @@ public class Importer {
         for (int i = 0; i < array.length(); i++) {
             JSONObject taskObject = array.getJSONObject(i);
             result.add(Task.Companion.fromString(taskObject.toString()));
+        }
+        return result;
+    }
+    public static ArrayList<Filter> createFilterList(String content) throws JSONException {
+        ArrayList<Filter> result = new ArrayList<>();
+        JSONObject reader = new JSONObject(content);
+        JSONArray array = reader.getJSONArray("filters");
+        for (int i = 0; i < array.length(); i++) {
+            JSONObject filterObject = array.getJSONObject(i);
+            result.add(Filter.Companion.fromString(filterObject.toString()));
         }
         return result;
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/Filter.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/Filter.kt
@@ -1,0 +1,65 @@
+package ca.pkay.rcloneexplorer.Items
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonNames
+import org.json.JSONObject
+
+@Serializable
+data class Filter(var id: Long) {
+    @JsonNames("name") var title = ""
+
+    private var filters = ""
+
+    override fun toString(): String {
+        return "$title: $filters"
+    }
+
+    companion object {
+        var TABLE_NAME = "filter_table"
+        var COLUMN_NAME_ID = "filter_id"
+        var COLUMN_NAME_TITLE = "filter_title"
+        var COLUMN_NAME_FILTERS = "filter_filters"
+
+        fun fromString(json: String): Filter {
+            return Json.decodeFromString(json)
+        }
+    }
+
+    fun asJSON(): JSONObject {
+        return JSONObject(Json.encodeToString(this))
+    }
+
+    fun setFiltersRaw(filters: String)
+    {
+        this.filters = filters;
+    }
+    fun getFiltersRaw(): String
+    {
+        return filters;
+    }
+    fun getFilters(): ArrayList<FilterEntry>
+    {
+        val filters = ArrayList<FilterEntry>()
+        val f = this.filters.split(System.lineSeparator())
+        for (filter in f) {
+            if (filter == "") continue
+            val filterType = if(filter.substring(0, 1) == "+") FilterEntry.FILTER_INCLUDE else FilterEntry.FILTER_EXCLUDE
+            val filterText = filter.substring(1)
+            filters.add(FilterEntry(filterType, filterText))
+        }
+        return filters;
+    }
+    fun setFilters(filterEntries: List<FilterEntry>)
+    {
+        var filters = ""
+
+        for (filter in filterEntries) {
+            filters += if(filter.filterType == FilterEntry.FILTER_INCLUDE) "+" else "-"
+            filters += filter.filter
+            filters += System.lineSeparator()
+        }
+        this.filters = filters
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/FilterEntry.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/FilterEntry.java
@@ -1,0 +1,21 @@
+package ca.pkay.rcloneexplorer.Items;
+
+import android.content.Context;
+
+import ca.pkay.rcloneexplorer.R;
+
+public class FilterEntry {
+
+    public static final int FILTER_INCLUDE = 0;
+    public static final int FILTER_EXCLUDE = 1;
+
+    public int filterType = FILTER_EXCLUDE;
+
+    public String filter;
+
+
+    public FilterEntry(int filterType, String filter) {
+        this.filterType = filterType;
+        this.filter = filter;
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/Task.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/Task.kt
@@ -17,7 +17,7 @@ data class Task(var id: Long) {
     @JsonNames("syncDirection") var direction = 0
     var md5sum = TASK_MD5SUM_DEFAULT
     var wifionly = TASK_WIFIONLY_DEFAULT
-    var exclude = ""
+    var filterId: Long? = null
     var deleteExcluded = false;
 
     override fun toString(): String {
@@ -35,7 +35,7 @@ data class Task(var id: Long) {
         var COLUMN_NAME_SYNC_DIRECTION = "task_direction"
         var COLUMN_NAME_MD5SUM = "task_use_md5sum"
         var COLUMN_NAME_WIFI_ONLY = "task_use_only_wifi"
-        var COLUMN_NAME_EXCLUDE = "task_exclude"
+        var COLUMN_NAME_FILTER_ID = "task_filter_id"
         var COLUMN_NAME_DELETE_EXCLUDED = "task_delete_excluded"
 
         const val TASK_MD5SUM_DEFAULT = false

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Items/Task.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Items/Task.kt
@@ -17,6 +17,8 @@ data class Task(var id: Long) {
     @JsonNames("syncDirection") var direction = 0
     var md5sum = TASK_MD5SUM_DEFAULT
     var wifionly = TASK_WIFIONLY_DEFAULT
+    var exclude = ""
+    var deleteExcluded = false;
 
     override fun toString(): String {
         return "$title: $remoteId: $remoteType: $remotePath: $localPath: $direction"
@@ -33,6 +35,8 @@ data class Task(var id: Long) {
         var COLUMN_NAME_SYNC_DIRECTION = "task_direction"
         var COLUMN_NAME_MD5SUM = "task_use_md5sum"
         var COLUMN_NAME_WIFI_ONLY = "task_use_only_wifi"
+        var COLUMN_NAME_EXCLUDE = "task_exclude"
+        var COLUMN_NAME_DELETE_EXCLUDED = "task_delete_excluded"
 
         const val TASK_MD5SUM_DEFAULT = false
         const val TASK_WIFIONLY_DEFAULT = false

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -47,6 +47,7 @@ import java.util.zip.ZipOutputStream;
 import ca.pkay.rcloneexplorer.Database.json.Exporter;
 import ca.pkay.rcloneexplorer.Database.json.SharedPreferencesBackup;
 import ca.pkay.rcloneexplorer.Items.FileItem;
+import ca.pkay.rcloneexplorer.Items.FilterEntry;
 import ca.pkay.rcloneexplorer.Items.RemoteItem;
 import ca.pkay.rcloneexplorer.Items.SyncDirectionObject;
 import ca.pkay.rcloneexplorer.rclone.Provider;
@@ -670,10 +671,10 @@ public class Rclone {
      */
     @Deprecated
     public Process sync(RemoteItem remoteItem, String localPath, String remotePath, int syncDirection) {
-        return sync(remoteItem, localPath, remotePath, syncDirection, false, "", false);
+        return sync(remoteItem, localPath, remotePath, syncDirection, false, new ArrayList<>(0), false);
     }
 
-    public Process sync(RemoteItem remoteItem, String localPath, String remotePath, int syncDirection, boolean useMD5Sum, String exclude, boolean deleteExcluded) {
+    public Process sync(RemoteItem remoteItem, String localPath, String remotePath, int syncDirection, boolean useMD5Sum, ArrayList<FilterEntry> filters, boolean deleteExcluded) {
         String[] command;
         String remoteName = remoteItem.getName();
         String localRemotePath = (remoteItem.isRemoteType(RemoteItem.LOCAL)) ? getLocalRemotePathPrefix(remoteItem, context)  + "/" : "";
@@ -689,15 +690,9 @@ public class Rclone {
             defaultParameter.add("--delete-excluded");
         }
 
-        if(!Objects.equals(exclude, "")) {
-            String[] excludeParts = exclude.split(System.lineSeparator());
-
-            for (String excludePart : excludeParts) {
-                if(Objects.equals(excludePart, ""))
-                    continue;
-                defaultParameter.add("--exclude");
-                defaultParameter.add(excludePart);
-            }
+        for (FilterEntry filter : filters) {
+            defaultParameter.add("--filter");
+            defaultParameter.add((filter.filterType == FilterEntry.FILTER_INCLUDE ? "+ " : "- ") + filter.filter);
         }
 
         if (syncDirection == SyncDirectionObject.SYNC_LOCAL_TO_REMOTE) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -669,10 +670,10 @@ public class Rclone {
      */
     @Deprecated
     public Process sync(RemoteItem remoteItem, String localPath, String remotePath, int syncDirection) {
-        return sync(remoteItem, localPath, remotePath, syncDirection, false);
+        return sync(remoteItem, localPath, remotePath, syncDirection, false, "", false);
     }
 
-    public Process sync(RemoteItem remoteItem, String localPath, String remotePath, int syncDirection, boolean useMD5Sum) {
+    public Process sync(RemoteItem remoteItem, String localPath, String remotePath, int syncDirection, boolean useMD5Sum, String exclude, boolean deleteExcluded) {
         String[] command;
         String remoteName = remoteItem.getName();
         String localRemotePath = (remoteItem.isRemoteType(RemoteItem.LOCAL)) ? getLocalRemotePathPrefix(remoteItem, context)  + "/" : "";
@@ -683,6 +684,20 @@ public class Rclone {
 
         if(useMD5Sum){
             defaultParameter.add("--checksum");
+        }
+        if(deleteExcluded){
+            defaultParameter.add("--delete-excluded");
+        }
+
+        if(!Objects.equals(exclude, "")) {
+            String[] excludeParts = exclude.split(System.lineSeparator());
+
+            for (String excludePart : excludeParts) {
+                if(Objects.equals(excludePart, ""))
+                    continue;
+                defaultParameter.add("--exclude");
+                defaultParameter.add(excludePart);
+            }
         }
 
         if (syncDirection == SyncDirectionObject.SYNC_LOCAL_TO_REMOTE) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FilterEntryRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FilterEntryRecyclerViewAdapter.java
@@ -1,0 +1,127 @@
+package ca.pkay.rcloneexplorer.RecyclerViewAdapters;
+
+
+import android.content.Context;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.EditText;
+import android.widget.ImageButton;
+import android.widget.Spinner;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.widget.PopupMenu;
+import androidx.recyclerview.widget.RecyclerView;
+
+
+import java.util.List;
+
+import ca.pkay.rcloneexplorer.Items.FilterEntry;
+import ca.pkay.rcloneexplorer.R;
+
+public class FilterEntryRecyclerViewAdapter extends RecyclerView.Adapter<FilterEntryRecyclerViewAdapter.ViewHolder> {
+    private List<FilterEntry> filterEntries;
+    private View view;
+    private final Context context;
+
+
+    public FilterEntryRecyclerViewAdapter(List<FilterEntry> filterEntries, Context context) {
+        this.filterEntries = filterEntries;
+        this.context = context;
+    }
+
+    @NonNull
+    @Override
+    public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
+        view = LayoutInflater.from(parent.getContext()).inflate(R.layout.fragment_filter_item, parent, false);
+        return new ViewHolder(view);
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull final ViewHolder holder, final int position) {
+        final FilterEntry selectedFilterEntry = filterEntries.get(position);
+
+        holder.filterText.setText(selectedFilterEntry.filter);
+        holder.filterText.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                selectedFilterEntry.filter = s.toString();
+            }
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+
+
+
+
+        ArrayAdapter<String> spinnerAdapter = new ArrayAdapter<>(holder.itemView.getContext(),
+                android.R.layout.simple_spinner_item, new String[]{ context.getString(R.string.filter_entry_filtertype_include), context.getString(R.string.filter_entry_filtertype_exclude) });
+        holder.filterTypeSpinner.setAdapter(spinnerAdapter);
+        holder.filterTypeSpinner.setSelection(selectedFilterEntry.filterType);
+        holder.filterTypeSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int pos, long id) {
+                selectedFilterEntry.filterType = pos;
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {}
+        });
+
+        holder.fileOptions.setOnClickListener(v-> {
+            showFileMenu(v, selectedFilterEntry);
+        });
+
+    }
+
+    public void removeItem(FilterEntry filterEntry) {
+        int index = filterEntries.indexOf(filterEntry);
+        if (index >= 0) {
+            filterEntries.remove(index);
+            notifyItemRemoved(index);
+        }
+    }
+
+    @Override
+    public int getItemCount() {
+        return filterEntries.size();
+    }
+
+    private void showFileMenu(View view, final FilterEntry filterEntry) {
+        PopupMenu popupMenu = new PopupMenu(context, view);
+        popupMenu.getMenuInflater().inflate(R.menu.filter_entry_item_menu, popupMenu.getMenu());
+        popupMenu.setOnMenuItemClickListener(item -> {
+            switch (item.getItemId()) {
+                case R.id.action_delete_filter_entry:
+                    removeItem(filterEntry);
+                    break;
+                default:
+                    return false;
+            }
+            return true;
+        });
+        popupMenu.show();
+    }
+
+    public static class ViewHolder extends RecyclerView.ViewHolder {
+
+        final View view;
+        final Spinner filterTypeSpinner;
+        final EditText filterText;
+        final ImageButton fileOptions;
+
+        ViewHolder(View itemView) {
+            super(itemView);
+            this.view = itemView;
+            this.filterTypeSpinner = view.findViewById(R.id.filter_entry_filter_type);
+            this.filterText = view.findViewById(R.id.filter_entry_filter_text);
+            this.fileOptions = view.findViewById(R.id.filter_entry_filter_options);
+        }
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TasksRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TasksRecyclerViewAdapter.java
@@ -143,7 +143,7 @@ public class TasksRecyclerViewAdapter extends RecyclerView.Adapter<TasksRecycler
 
     private void copyTask(Task task) {
         task.setTitle(task.getTitle() + context.getString(R.string.task_copy_suffix));
-        Task newTask = (new DatabaseHandler(context)).createTask(task);
+        Task newTask = (new DatabaseHandler(context)).createTask(task, false);
         tasks.add(newTask);
         notifyItemInserted(tasks.size() - 1);
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TriggerRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/TriggerRecyclerViewAdapter.java
@@ -148,7 +148,7 @@ public class TriggerRecyclerViewAdapter extends RecyclerView.Adapter<RecyclerVie
 
     private void copyTrigger(Trigger trigger){
         trigger.setTitle(trigger.getTitle() + context.getString(R.string.trigger_copy_suffix));
-        Trigger newTrigger = (new DatabaseHandler(context)).createTrigger(trigger);
+        Trigger newTrigger = (new DatabaseHandler(context)).createTrigger(trigger, false);
         triggers.add(newTrigger);
         notifyItemInserted(triggers.size() - 1);
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/SpinnerAdapters/FilterSpinnerAdapter.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/SpinnerAdapters/FilterSpinnerAdapter.kt
@@ -1,0 +1,32 @@
+package ca.pkay.rcloneexplorer.SpinnerAdapters
+
+import android.content.Context
+import android.graphics.Typeface
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import ca.pkay.rcloneexplorer.R
+
+class FilterSpinnerAdapter(context: Context, resource: Int, objects: List<String?>) :
+        ArrayAdapter<String?>(context, resource, objects) {
+
+    override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+        val view = convertView ?: LayoutInflater.from(context).inflate(android.R.layout.simple_spinner_dropdown_item, parent, false)
+        val textView = view.findViewById<TextView>(android.R.id.text1)
+
+        // Set special styling for "No Filter" option
+        if (getItem(position) == context.getString(R.string.task_edit_filter_nofilter)) {
+            textView.setTextColor(ContextCompat.getColor(context, android.R.color.white))
+            textView.setTypeface(null, Typeface.BOLD)
+        } else {
+            textView.setTextColor(ContextCompat.getColor(context, android.R.color.white))
+            textView.setTypeface(null, Typeface.NORMAL)
+        }
+
+        textView.text = getItem(position)
+        return view
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -161,7 +161,9 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 mTask.localPath,
                 mTask.remotePath,
                 mTask.direction,
-                mTask.md5sum
+                mTask.md5sum,
+                mTask.exclude,
+                mTask.deleteExcluded
             )
             handleSync(mTitle)
             sendUploadFinishedBroadcast(remoteItem.name, mTask.remotePath)

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -156,13 +156,15 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
             mTitle = mTask.remotePath
         }
         if(arePreconditionsMet()) {
+            val taskFilter = if(mTask.filterId != null ) mDatabase.getFilter(mTask.filterId!!) else null;
+            val taskFilterList = taskFilter?.getFilters() ?: ArrayList()
             sRcloneProcess = mRclone.sync(
                 remoteItem,
                 mTask.localPath,
                 mTask.remotePath,
                 mTask.direction,
                 mTask.md5sum,
-                mTask.exclude,
+                taskFilterList,
                 mTask.deleteExcluded
             )
             handleSync(mTitle)

--- a/app/src/main/res/layout/activity_filter.xml
+++ b/app/src/main/res/layout/activity_filter.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="ca.pkay.rcloneexplorer.Activities.FilterActivity">
+
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="6dp"
+        android:paddingEnd="6dp"
+        app:elevation="0dp">
+
+        <com.google.android.material.card.MaterialCardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="4dp"
+            app:cardCornerRadius="@dimen/cardCornerRadius"
+            style="@style/MainViewToolbar"
+            app:cardElevation="2dp"
+            app:strokeWidth="0dp">
+
+            <androidx.appcompat.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:theme="@style/MainViewToolbar"
+                style="@style/MainViewToolbar"
+                android:orientation="horizontal" />
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="16dp"
+            android:paddingEnd="16dp">
+
+            <de.felixnuesse.ui.BreadcrumbView
+                android:id="@+id/breadcrumb_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_marginTop="8dp"
+                android:layout_marginBottom="8dp"
+                android:scrollbars="none"
+                android:visibility="gone" />
+        </FrameLayout>
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <include layout="@layout/content_filter" />
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/saveButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/fab_margin"
+        android:tint="@color/white"
+        app:srcCompat="@drawable/ic_twotone_save_24" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_filter.xml
+++ b/app/src/main/res/layout/activity_filter.xml
@@ -6,7 +6,6 @@
     android:layout_height="match_parent"
     tools:context="ca.pkay.rcloneexplorer.Activities.FilterActivity">
 
-
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/appBar"
         android:layout_width="match_parent"
@@ -35,21 +34,6 @@
 
         </com.google.android.material.card.MaterialCardView>
 
-        <FrameLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="16dp"
-            android:paddingEnd="16dp">
-
-            <de.felixnuesse.ui.BreadcrumbView
-                android:id="@+id/breadcrumb_view"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:layout_marginTop="8dp"
-                android:layout_marginBottom="8dp"
-                android:scrollbars="none"
-                android:visibility="gone" />
-        </FrameLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
     <include layout="@layout/content_filter" />

--- a/app/src/main/res/layout/content_filter.xml
+++ b/app/src/main/res/layout/content_filter.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/create_task_layout"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:orientation="vertical">
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="8dp"
+                style="@style/SecondaryCardStyle"
+                app:cardCornerRadius="@dimen/cardCornerRadius"
+                app:contentPadding="@dimen/cardPadding">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:padding="8dp"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/label_name"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:text="@string/filter_edit_label_name"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+                        android:textSize="24sp" />
+
+                    <EditText
+                        android:id="@+id/filter_title_textfield"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="8dp"
+                        android:autofillHints=""
+                        android:hint="@string/filter_edit_hint_title"
+                        android:inputType="text"
+                        android:minHeight="48dp" />
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+            <androidx.cardview.widget.CardView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="8dp"
+                style="@style/SecondaryCardStyle"
+                app:cardCornerRadius="@dimen/cardCornerRadius"
+                app:contentPadding="@dimen/cardPadding">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/label_filters"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
+                        android:text="@string/filter_edit_label_filters"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+                        android:textSize="24sp" />
+
+                    <androidx.recyclerview.widget.RecyclerView
+                        android:id="@+id/filter_filterlist"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent">
+
+                    </androidx.recyclerview.widget.RecyclerView>
+
+                    <Button
+                        android:id="@+id/filter_add_filterentry_button"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/filter_edit_add_filter_button" />
+
+                </LinearLayout>
+            </androidx.cardview.widget.CardView>
+
+            <Space
+                android:layout_width="wrap_content"
+                android:minHeight="48dp"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
+    </ScrollView>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/content_task.xml
+++ b/app/src/main/res/layout/content_task.xml
@@ -42,7 +42,7 @@
                         android:textSize="24sp" />
 
                     <EditText
-                        android:id="@+id/task_title_textfield"
+                        android:id="@+id/filter_title_textfield"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="8dp"
@@ -102,7 +102,7 @@
                     android:orientation="vertical">
 
                     <TextView
-                        android:id="@+id/label_direction"
+                        android:id="@+id/label_filters"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/task_edit_label_direction"
@@ -207,6 +207,7 @@
 
             <androidx.cardview.widget.CardView
                 style="@style/SecondaryCardStyle"
+                android:theme="@style/SecondaryCardStyle"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:layout_margin="8dp"
@@ -219,30 +220,55 @@
                     android:orientation="vertical">
 
                     <TextView
-                        android:id="@+id/label_exclude"
+                        android:id="@+id/label_filter"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_margin="8dp"
-                        android:text="@string/task_edit_label_exclude"
+                        android:text="@string/task_edit_label_filter"
                         android:textAppearance="@style/TextAppearance.AppCompat.Display1"
                         android:textSize="24sp" />
 
-                    <EditText
-                        android:id="@+id/task_exclude_textfield"
+                    <FrameLayout
+                        android:id="@+id/task_edit_filter_holder"
                         android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:ems="10"
-                        android:gravity="start|top"
-                        android:hint="@string/task_edit_hint_exclude"
-                        android:inputType="textMultiLine"
-                        android:minHeight="48dp"
-                        android:singleLine="false" />
+                        android:layout_height="match_parent">
+
+                        <LinearLayout
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent"
+                            android:orientation="horizontal">
+
+                            <Spinner
+                                android:id="@+id/task_filter_spinner"
+                                android:layout_width="0dp"
+                                android:layout_height="wrap_content"
+                                android:layout_weight="1"
+                                android:minHeight="48dp" />
+
+                            <ImageButton
+                                android:id="@+id/task_edit_filter_options_button"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:layout_alignParentEnd="true"
+                                android:layout_centerVertical="true"
+                                android:background="?selectableItemBackgroundBorderless"
+                                android:contentDescription="@string/task_edit_filter_options_button"
+                                android:minWidth="48dp"
+                                android:minHeight="48dp"
+                                android:padding="4dp"
+                                android:src="@drawable/ic_more_vert"
+                                app:layout_constraintEnd_toEndOf="parent"
+                                app:layout_constraintTop_toTopOf="parent" />
+
+                        </LinearLayout>
+
+                    </FrameLayout>
 
                     <TextView
                         android:id="@+id/description_exclude"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/task_edit_description_exclude" />
+                        android:text="@string/task_edit_description_filter" />
 
                     <Switch
                         android:id="@+id/task_exclude_delete_toggle"

--- a/app/src/main/res/layout/content_task.xml
+++ b/app/src/main/res/layout/content_task.xml
@@ -233,6 +233,12 @@
                         android:layout_width="match_parent"
                         android:layout_height="match_parent">
 
+                        <Button
+                            android:id="@+id/task_edit_filter_add_button"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/add_filter" />
+
                         <LinearLayout
                             android:layout_width="match_parent"
                             android:layout_height="match_parent"

--- a/app/src/main/res/layout/content_task.xml
+++ b/app/src/main/res/layout/content_task.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/create_task_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -203,6 +204,61 @@
                         android:minHeight="48dp" />
                 </LinearLayout>
             </androidx.cardview.widget.CardView>
+
+            <androidx.cardview.widget.CardView
+                style="@style/SecondaryCardStyle"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:layout_margin="8dp"
+                app:cardCornerRadius="@dimen/cardCornerRadius"
+                app:contentPadding="@dimen/cardPadding">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/label_exclude"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_margin="8dp"
+                        android:text="@string/task_edit_label_exclude"
+                        android:textAppearance="@style/TextAppearance.AppCompat.Display1"
+                        android:textSize="24sp" />
+
+                    <EditText
+                        android:id="@+id/task_exclude_textfield"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:ems="10"
+                        android:gravity="start|top"
+                        android:hint="@string/task_edit_hint_exclude"
+                        android:inputType="textMultiLine"
+                        android:minHeight="48dp"
+                        android:singleLine="false" />
+
+                    <TextView
+                        android:id="@+id/description_exclude"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/task_edit_description_exclude" />
+
+                    <Switch
+                        android:id="@+id/task_exclude_delete_toggle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:minHeight="48dp"
+                        android:text="@string/task_edit_exclude_delete_toggle_text" />
+
+                </LinearLayout>
+
+            </androidx.cardview.widget.CardView>
+
+            <Space
+                android:layout_width="wrap_content"
+                android:minHeight="48dp"
+                android:layout_height="wrap_content" />
 
         </LinearLayout>
 

--- a/app/src/main/res/layout/content_task.xml
+++ b/app/src/main/res/layout/content_task.xml
@@ -42,7 +42,7 @@
                         android:textSize="24sp" />
 
                     <EditText
-                        android:id="@+id/filter_title_textfield"
+                        android:id="@+id/task_title_textfield"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_marginBottom="8dp"
@@ -102,7 +102,7 @@
                     android:orientation="vertical">
 
                     <TextView
-                        android:id="@+id/label_filters"
+                        android:id="@+id/label_direction"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:text="@string/task_edit_label_direction"
@@ -255,8 +255,6 @@
                                 android:id="@+id/task_edit_filter_options_button"
                                 android:layout_width="wrap_content"
                                 android:layout_height="wrap_content"
-                                android:layout_alignParentEnd="true"
-                                android:layout_centerVertical="true"
                                 android:background="?selectableItemBackgroundBorderless"
                                 android:contentDescription="@string/task_edit_filter_options_button"
                                 android:minWidth="48dp"

--- a/app/src/main/res/layout/fragment_filter_item.xml
+++ b/app/src/main/res/layout/fragment_filter_item.xml
@@ -6,50 +6,39 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">
 
-    <androidx.cardview.widget.CardView
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_margin="8dp"
-        android:elevation="4dp"
-        android:theme="@style/SecondaryCardStyle"
-        style="@style/SecondaryCardStyle"
-        app:cardCornerRadius="@dimen/cardCornerRadius">
+        android:orientation="horizontal">
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:orientation="horizontal">
+        <Spinner
+            android:id="@+id/filter_entry_filter_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp" />
 
-            <Spinner
-                android:id="@+id/filter_entry_filter_type"
-                android:layout_width="wrap_content"
-                android:minHeight="48dp"
-                android:layout_height="wrap_content" />
+        <EditText
+            android:id="@+id/filter_entry_filter_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:ems="10"
+            android:hint="@string/filter_type_exclude"
+            android:importantForAutofill="no"
+            android:inputType="text"
+            android:text="Name" />
 
-            <EditText
-                android:id="@+id/filter_entry_filter_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:ems="10"
-                android:inputType="text"
-                android:hint="@string/filter_type_exclude"
-                android:importantForAutofill="no"
-                android:text="Name" />
-
-            <ImageButton
-                android:id="@+id/filter_entry_filter_options"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:background="?selectableItemBackgroundBorderless"
-                android:contentDescription="@string/file_options_content_description"
-                android:minWidth="48dp"
-                android:minHeight="48dp"
-                android:padding="4dp"
-                android:src="@drawable/ic_more_vert" />
-        </LinearLayout>
-
-    </androidx.cardview.widget.CardView>
+        <ImageButton
+            android:id="@+id/filter_entry_filter_options"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:background="?selectableItemBackgroundBorderless"
+            android:contentDescription="@string/file_options_content_description"
+            android:minWidth="48dp"
+            android:minHeight="48dp"
+            android:padding="4dp"
+            android:src="@drawable/ic_more_vert" />
+    </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_filter_item.xml
+++ b/app/src/main/res/layout/fragment_filter_item.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical">
+
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_margin="8dp"
+        android:elevation="4dp"
+        android:theme="@style/SecondaryCardStyle"
+        style="@style/SecondaryCardStyle"
+        app:cardCornerRadius="@dimen/cardCornerRadius">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="horizontal">
+
+            <Spinner
+                android:id="@+id/filter_entry_filter_type"
+                android:layout_width="wrap_content"
+                android:minHeight="48dp"
+                android:layout_height="wrap_content" />
+
+            <EditText
+                android:id="@+id/filter_entry_filter_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:ems="10"
+                android:inputType="text"
+                android:hint="@string/filter_type_exclude"
+                android:importantForAutofill="no"
+                android:text="Name" />
+
+            <ImageButton
+                android:id="@+id/filter_entry_filter_options"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentEnd="true"
+                android:layout_centerVertical="true"
+                android:background="?selectableItemBackgroundBorderless"
+                android:contentDescription="@string/file_options_content_description"
+                android:minWidth="48dp"
+                android:minHeight="48dp"
+                android:padding="4dp"
+                android:src="@drawable/ic_more_vert" />
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_filter_item.xml
+++ b/app/src/main/res/layout/fragment_filter_item.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:theme="@style/SecondaryCardStyle"
     xmlns:tools="http://schemas.android.com/tools"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical">

--- a/app/src/main/res/layout/fragment_filter_item.xml
+++ b/app/src/main/res/layout/fragment_filter_item.xml
@@ -32,8 +32,6 @@
             android:id="@+id/filter_entry_filter_options"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
             android:background="?selectableItemBackgroundBorderless"
             android:contentDescription="@string/file_options_content_description"
             android:minWidth="48dp"

--- a/app/src/main/res/menu/filter_entry_item_menu.xml
+++ b/app/src/main/res/menu/filter_entry_item_menu.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_delete_filter_entry"
+        android:icon="@drawable/ic_delete_black"
+        android:title="@string/delete" />
+</menu>

--- a/app/src/main/res/menu/filter_item_menu.xml
+++ b/app/src/main/res/menu/filter_item_menu.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_edit_filter"
+        android:icon="@drawable/ic_edit_black"
+        android:title="@string/edit" />
+    <item
+        android:id="@+id/action_delete_filter"
+        android:icon="@drawable/ic_delete_black"
+        android:title="@string/delete" />
+    <item
+        android:id="@+id/action_create_new_filter"
+        android:icon="@drawable/ic_add"
+        android:title="@string/add_filter" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -348,6 +348,7 @@
     <string name="operation_report_fail_short_content">%d Tasks failed</string>
     <string name="pin_to_dektop">Pin to Home</string>
     <string name="title_activity_task">Create a new Task</string>
+    <string name="title_activity_filter">Create a new Filter</string>
     <!-- Strings used for fragments for navigation -->
 
     <string name="task_edit_label_name">General Information</string>
@@ -357,10 +358,20 @@
     <string name="task_edit_hint_title">Title</string>
     <string name="task_edit_hint_local">Local Path</string>
     <string name="task_edit_hint_remote">Remote Path</string>
-    <string name="task_edit_label_exclude">Exclude</string>
-    <string name="task_edit_hint_exclude">**/.thumbnails/**</string>
-    <string name="task_edit_description_exclude">Patterns of files/folders to exclude, separated on newlines.</string>
+    <string name="task_edit_label_filter">Filter</string>
+    <string name="task_edit_hint_filter">**/.thumbnails/**</string>
+    <string name="task_edit_filter_nofilter">No filter</string>
+    <string name="task_edit_description_filter">Select a filter to filter file/folder patterns.</string>
     <string name="task_edit_exclude_delete_toggle_text">Delete excluded files from destination</string>
+    <string name="task_edit_filter_options_button">Filter Options</string>
+    <string name="filter_edit_label_name">General Information</string>
+    <string name="filter_edit_label_filters">Filters</string>
+    <string name="filter_edit_hint_title">Title</string>
+    <string name="filter_edit_add_filter_button">Add filter</string>
+    <string name="filter_data_validation_error_no_title">Please give your filter a name</string>
+    <string name="filter_entry_filter_text">**/.thumbnails/**</string>
+    <string name="filter_entry_filtertype_include">Include</string>
+    <string name="filter_entry_filtertype_exclude">Exclude</string>
     <string name="rcd_service_notification_running_in_background">Rclone runs in the background</string>
     <string name="rcd_service_notification_no_active_jobs">No active jobs.</string>
     <string name="rcd_service_notification_btn_stop_all">Stop All</string>
@@ -446,6 +457,7 @@
     <string name="trigger_task_label">Task:</string>
     <string name="trigger_save_notasks">There are no tasks!</string>
     <string name="taskactivity_task_not_found">The specified task could not be found.</string>
+    <string name="filteractivity_filter_not_found">The specified filter could not be found.</string>
     <string name="triggeractivity_trigger_not_found">Trigger not found.</string>
     <string name="task_item_label_from">From:</string>
     <string name="task_item_label_to">To:</string>
@@ -455,6 +467,7 @@
     <string name="no_trigger_warning">There are no triggers.</string>
     <string name="add_trigger">Add a Trigger</string>
     <string name="add_task">Add a Task</string>
+    <string name="add_filter">Add a Filter</string>
     <string name="retry_failed_sync">Retry</string>
     <string name="taskfragment_no_tasks_warning">There are no tasks. Add one here!</string>
     <string name="auto_theme">Follow System Theme</string>
@@ -473,6 +486,8 @@
     <string name="description_sync_direction_copy_toremote">Copy new or modified files from local storage to remote storage. No files are deleted, existing files on the remote may be overwritten.</string>
     <string name="description_sync_direction_copy_tolocal">Copy new or modified files from remote storage to local storage. No files are deleted, existing files on the local storage may be overwritten.</string>
     <string name="description_sync_direction_sync_bidirectional">Make sure local and remote storage have the same files by transferring, downloading, and deleting files as needed to maintain an identical folder structure.</string>
+    <string name="filter_type_include">Include</string>
+    <string name="filter_type_exclude">Exclude</string>
     <string name="intro_success">Success!</string>
     <string name="intro_successful_setup">You are now ready to start!</string>
     <string name="status_offendingfile">"The offending File: "</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -357,6 +357,10 @@
     <string name="task_edit_hint_title">Title</string>
     <string name="task_edit_hint_local">Local Path</string>
     <string name="task_edit_hint_remote">Remote Path</string>
+    <string name="task_edit_label_exclude">Exclude</string>
+    <string name="task_edit_hint_exclude">**/.thumbnails/**</string>
+    <string name="task_edit_description_exclude">Patterns of files/folders to exclude, separated on newlines.</string>
+    <string name="task_edit_exclude_delete_toggle_text">Delete excluded files from destination</string>
     <string name="rcd_service_notification_running_in_background">Rclone runs in the background</string>
     <string name="rcd_service_notification_no_active_jobs">No active jobs.</string>
     <string name="rcd_service_notification_btn_stop_all">Stop All</string>


### PR DESCRIPTION
Adds option to exclude certain file patterns. UI inspired by RClone Browser. 
Could fix at least part of this issue [79](https://github.com/newhinton/Round-Sync/issues/79) and provide a workaround for issue [126](https://github.com/newhinton/Round-Sync/issues/126)

### Reason for this request
I use this app to backup all files on my phone, since the Android folder is protected, I am getting errors and this prevents files from being deleted on the remote.

I read the discussion on issue [79](https://github.com/newhinton/Round-Sync/issues/79) and understand you would rather have some file/folder multi-select option instead for a better user experience. Since that issue is already almost a year ago, I hope you can consider this in the mean time.

Please let me know if I can improve the in-app explanation text or the code.


### Screenshot
![Screenshot](https://github.com/newhinton/Round-Sync/assets/1367566/1f9834c0-90a7-49ff-94c6-909c265ad13b)
