### PR TITLE
Read isDarkTheme as String when importing config

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/SharedPreferencesBackup.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/SharedPreferencesBackup.java
@@ -98,8 +98,8 @@ public class SharedPreferencesBackup {
         // The type changed. So we try to use boolean first, and if it fails we use the proper int
         Object darkTheme = jsonObject.get("isDarkTheme");
         int valueForTheme;
-        if (darkTheme instanceof Integer) {
-            valueForTheme = (Integer) darkTheme;
+        if (darkTheme instanceof String) {
+            valueForTheme = Integer.parseInt((String) darkTheme);
         } else {
            if((boolean) darkTheme) {
                valueForTheme = DARK;


### PR DESCRIPTION
Running v2.5.4

1. Dark mode enabled
2. Export config
3. Do not modify the zip file
4. Import config by selecting the zip file created in step 2
5. Error message: `Failed to import. Your Zip does not contain Triggers and Tasks!`

The export config function creates a `rcx.prefs` file which contains a string value for `isDarkTheme`:
```
{
    "isDarkTheme": "1"
}
```
However, the import config function is expecting an Integer, so it fails to load the config.
The code seems to suggest that the value of `isDarkTheme` should be a string for backward compatibility.
However the import config function looks for an Integer, so the fix here is to look for a String instead.
