### PR TITLE
Sync file modified time

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -180,7 +180,7 @@ public class Rclone {
 
         // ignore chtimes errors
         // ref: https://github.com/rclone/rclone/issues/2446
-        environmentValues.add("RCLONE_LOCAL_NO_SET_MODTIME=true");
+        // environmentValues.add("RCLONE_LOCAL_NO_SET_MODTIME=true");
 
         // Allow the caller to overwrite any option for special cases
         Iterator<String> envVarIter = environmentValues.iterator();


### PR DESCRIPTION
Enables modified time synchronization to local.
I have a use case where I want to use date modified metadata for sorting, so I would like for that to be synced from the remote.

From what I can see in https://github.com/rclone/rclone/issues/2446, this functionality was disabled since it caused issues on Android versions < 7, but RoundSync supports Android 7+, so that should not be a problem.

Possible fix for #124 