### PR TITLE
Disable Icon Tint For Thumbnails

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RecyclerViewAdapters/FileExplorerRecyclerViewAdapter.java
@@ -107,6 +107,9 @@ public class FileExplorerRecyclerViewAdapter extends RecyclerView.Adapter<FileEx
             boolean localLoad = item.getRemote().getType() == RemoteItem.SAFW;
             String mimeType = item.getMimeType();
             if ((mimeType.startsWith("image/") || mimeType.startsWith("video/")) && item.getSize() <= sizeLimit) {
+                // Tint is applied across the board in the theme, so we want to disable it for thumbnails.
+                holder.fileIcon.setImageTintList(null);
+
                 RequestOptions glideOption = new RequestOptions()
                         .centerCrop()
                         .diskCacheStrategy(DiskCacheStrategy.ALL)


### PR DESCRIPTION
The introduction of themes seemed to apply tint globally to multiple View elements, including the ImageView used to display thumbnails. Consequently, while Glide would successfully load thumbnails, they would render as completely white or black (depending on the theme). We can workaround this by dynamically disabling tint when using Glide to load thumbnails.

This fixes #166 and #310 .