### PR TITLE
fix: allow custom URL input for Seafile remotes (and others where relevant)

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/DynamicRemoteConfigFragment.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RemoteConfig/DynamicRemoteConfigFragment.kt
@@ -342,7 +342,7 @@ class DynamicRemoteConfigFragment(private val mProviderTitle: String, private va
         )
 
         input.setAdapter(adapter)
-        input.isEnabled = false
+        input.isEnabled = !option.exclusive
 
         textinput.addView(input)
 


### PR DESCRIPTION
Solves https://github.com/newhinton/Round-Sync/issues/380 

## Problem

Editable dropdown fields are hardcoded to `false`! This means in order to add and use our own self-hosted seafile data, we need _hacky_ solutions, like manually editing conf files. 

## Solution

Make it conditional based on rclone's `exclusive` metadata flag, which indicates whether or not custom values are allowed.

The app should already parse this flag from the rclone config providers JSON into `ProviderOption.exclusive`

Since Seafile's URL option does not set `Exclusive: true` in rclone's source, custom URLs will now be permitted.

<details>
<summary>Example of how to verifying the rclone config Seafile uses (Debian/Ubuntu)</summary>

```bash
# Install rclone if you haven't already
sudo apt install rclone -y

# Extract relevant URL config from seafile
rclone config providers | jq '.[] | select(.Name == "seafile") | .Options[] | select(.Name == "url")'
```

Note there's no `Exclusive` field (defaults to `false`):
```json
{
  "Name": "url",
  "Help": "URL of seafile host to connect to",
  "Provider": "",
  "Default": "",
  "Value": null,
  "Examples": [
    {
      "Value": "https://cloud.seafile.com/",
      "Help": "Connect to cloud.seafile.com",
      "Provider": ""
    }
  ],
  "ShortOpt": "",
  "Hide": 0,
  "Required": true,
  "IsPassword": false,
  "NoPrefix": false,
  "Advanced": false,
  "DefaultStr": "",
  "ValueStr": "",
  "Type": "string"
}
```

You can also verify that we parse this `Exclusive` field in `ProviderOption.kt` and set it to `item.exclusive`.

</details>

## Testing / Verify

Add a new Seafile remote and verify that:
1. The default URL appears as a dropdown choice
2. You can enter a custom URL