### PR TITLE
fix: StreamingService foreground crash, import crash, and sync change-detection bugs

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Importer.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Importer.java
@@ -33,7 +33,10 @@ public class Importer {
     public static ArrayList<Trigger> createTriggerlist(String content) throws JSONException {
         ArrayList<Trigger> result = new ArrayList<>();
         JSONObject reader = new JSONObject(content);
-        JSONArray array = reader.getJSONArray("trigger");
+        JSONArray array = reader.optJSONArray("trigger");
+        if (array == null) {
+            return result;
+        }
         for (int i = 0; i < array.length(); i++) {
             JSONObject triggerObject = array.getJSONObject(i);
             result.add(Trigger.Companion.fromString(triggerObject.toString()));
@@ -44,7 +47,10 @@ public class Importer {
     public static ArrayList<Task> createTasklist(String content) throws JSONException {
         ArrayList<Task> result = new ArrayList<>();
         JSONObject reader = new JSONObject(content);
-        JSONArray array = reader.getJSONArray("tasks");
+        JSONArray array = reader.optJSONArray("tasks");
+        if (array == null) {
+            return result;
+        }
         for (int i = 0; i < array.length(); i++) {
             JSONObject taskObject = array.getJSONObject(i);
             result.add(Task.Companion.fromString(taskObject.toString()));
@@ -54,7 +60,10 @@ public class Importer {
     public static ArrayList<Filter> createFilterList(String content) throws JSONException {
         ArrayList<Filter> result = new ArrayList<>();
         JSONObject reader = new JSONObject(content);
-        JSONArray array = reader.getJSONArray("filters");
+        JSONArray array = reader.optJSONArray("filters");
+        if (array == null) {
+            return result;
+        }
         for (int i = 0; i < array.length(); i++) {
             JSONObject filterObject = array.getJSONObject(i);
             result.add(Filter.Companion.fromString(filterObject.toString()));

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Fragments/FileExplorerFragment.java
@@ -2,6 +2,7 @@ package ca.pkay.rcloneexplorer.Fragments;
 
 import static ca.pkay.rcloneexplorer.util.ActivityHelper.tryStartActivity;
 import static ca.pkay.rcloneexplorer.util.ActivityHelper.tryStartActivityForResult;
+import static ca.pkay.rcloneexplorer.util.ActivityHelper.tryStartForegroundService;
 import static ca.pkay.rcloneexplorer.util.ActivityHelper.tryStartService;
 
 import android.annotation.SuppressLint;
@@ -703,7 +704,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             default:
                 return;
         }
-        tryStartService(context, intent);
+        tryStartForegroundService(context, intent);
     }
 
     private void emptyTrash() {
@@ -1306,7 +1307,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
                         }
                         // GH-87: Release old server
                         context.stopService(new Intent(context, StreamingService.class));
-                        tryStartService(context, intent);
+                        tryStartForegroundService(context, intent);
                     });
                     builder.setTitle(R.string.pick_a_protocol);
                     builder.show();
@@ -1929,7 +1930,7 @@ public class FileExplorerFragment extends Fragment implements   FileExplorerRecy
             serveIntent.putExtra(StreamingService.SERVE_PORT, port);
             // GH-87: Release old stream
             context.stopService(new Intent(context, StreamingService.class));
-            tryStartService(context, serveIntent);
+            tryStartForegroundService(context, serveIntent);
 
             Uri uri = Uri.parse("http://127.0.0.1:" + port)
                     .buildUpon()

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Log2File.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Log2File.java
@@ -22,6 +22,10 @@ public class Log2File {
 
     public void log(String message) {
         File path = context.getExternalFilesDir("logs");
+        if (path == null) {
+            FLog.e(TAG, "log: external storage not available, cannot write log");
+            return;
+        }
         File logFile = new File(path, "log.txt");
 
         clearLogsIfTooBif(logFile);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -697,10 +697,19 @@ public class Rclone {
         }
         ArrayList<String> directionParameter = new ArrayList<>();
 
-        if(useMD5Sum){
+        boolean isSftpRemote = remoteItem.isRemoteType(RemoteItem.SFTP);
+        if(useMD5Sum && !isSftpRemote){
             defaultParameter.add("--checksum");
         }
-        if(remoteItem.isRemoteType(RemoteItem.SFTP)){
+        if(isSftpRemote){
+            // Many SFTP servers (e.g. Synology restricted shells) can't run md5sum/sha1sum
+            // over SSH even though the files are reachable via SFTP. Disabling the remote
+            // hash commands avoids "corrupted on transfer: hashes differ" failures, but it
+            // also means no common hash type is left to compare with --checksum. If both
+            // were combined, rclone silently falls back to a size-only comparison and
+            // ignores modification time, so changed files of the same size never get
+            // re-synced. Skip --checksum here and let rclone use its default size+modtime
+            // comparison instead.
             defaultParameter.add("--sftp-md5sum-command");
             defaultParameter.add("none");
             defaultParameter.add("--sftp-sha1sum-command");

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -688,11 +688,23 @@ public class Rclone {
         String localRemotePath = (remoteItem.isRemoteType(RemoteItem.LOCAL)) ? getLocalRemotePathPrefix(remoteItem, context)  + "/" : "";
         String remoteSection = (remotePath.compareTo("//" + remoteName) == 0) ? remoteName + ":" + localRemotePath : remoteName + ":" + localRemotePath + remotePath;
 
-        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--stats-log-level", "NOTICE", "--log-level", "INFO", "--use-json-log"));
+        boolean loggingEnabled = PreferenceManager
+                .getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.pref_key_logs), false);
+        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--use-json-log"));
+        if (!loggingEnabled) {
+            defaultParameter.addAll(Arrays.asList("--stats-log-level", "NOTICE", "--log-level", "INFO"));
+        }
         ArrayList<String> directionParameter = new ArrayList<>();
 
         if(useMD5Sum){
             defaultParameter.add("--checksum");
+        }
+        if(remoteItem.isRemoteType(RemoteItem.SFTP)){
+            defaultParameter.add("--sftp-md5sum-command");
+            defaultParameter.add("none");
+            defaultParameter.add("--sftp-sha1sum-command");
+            defaultParameter.add("none");
         }
         if(deleteExcluded){
             defaultParameter.add("--delete-excluded");

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -181,9 +181,17 @@ public class Rclone {
         String tmpDir = context.getCacheDir().getAbsolutePath();
         environmentValues.add("TMPDIR=" + tmpDir);
 
-        // ignore chtimes errors
-        // ref: https://github.com/rclone/rclone/issues/2446
-        environmentValues.add("RCLONE_LOCAL_NO_SET_MODTIME=true");
+        // RCLONE_LOCAL_NO_SET_MODTIME used to be set here to work around chtimes
+        // crashes on old Android storage stacks (ref: rclone#2446). It makes the
+        // local backend's Precision() report ModTimeNotSupported unconditionally
+        // (backend/local/local.go), which makes rclone's default file comparison
+        // fall back to a silent size-only check for every sync, ignoring
+        // modification time entirely -- changed files of the same size never get
+        // re-synced. A failing chtimes() is not fatal in current rclone: a failed
+        // SetModTime is just logged and counted as an error, the transfer itself
+        // still succeeds (fs/operations/operations.go). So leave modtime-setting
+        // enabled and let rclone's own runtime precision probe (readPrecision())
+        // degrade gracefully per-remote if chtimes truly isn't supported there.
 
         // Allow the caller to overwrite any option for special cases
         Iterator<String> envVarIter = environmentValues.iterator();

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -688,7 +688,7 @@ public class Rclone {
         String localRemotePath = (remoteItem.isRemoteType(RemoteItem.LOCAL)) ? getLocalRemotePathPrefix(remoteItem, context)  + "/" : "";
         String remoteSection = (remotePath.compareTo("//" + remoteName) == 0) ? remoteName + ":" + localRemotePath : remoteName + ":" + localRemotePath + remotePath;
 
-        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--stats-log-level", "NOTICE", "--use-json-log"));
+        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--stats-log-level", "NOTICE", "--log-level", "INFO", "--use-json-log"));
         ArrayList<String> directionParameter = new ArrayList<>();
 
         if(useMD5Sum){

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RcloneRcd.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RcloneRcd.java
@@ -170,9 +170,9 @@ public class RcloneRcd {
         String tmpDir = context.getCacheDir().getAbsolutePath();
         environmentValues.add("TMPDIR=" + tmpDir);
 
-        // ignore chtimes errors
-        // ref: https://github.com/rclone/rclone/issues/2446
-        environmentValues.add("RCLONE_LOCAL_NO_SET_MODTIME=true");
+        // See Rclone.java getRcloneEnv() for why RCLONE_LOCAL_NO_SET_MODTIME is
+        // deliberately not set here: it forces rclone's local-backend file
+        // comparison to silently ignore modification time (size-only fallback).
         return environmentValues.toArray(new String[0]);
     }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Services/StreamingService.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Services/StreamingService.java
@@ -1,13 +1,13 @@
 package ca.pkay.rcloneexplorer.Services;
 
-import android.app.IntentService;
-import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
-import android.content.Context;
+import android.app.Service;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
+import android.os.IBinder;
+
 import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 
@@ -19,7 +19,7 @@ import ca.pkay.rcloneexplorer.util.FLog;
 import ca.pkay.rcloneexplorer.util.NotificationUtils;
 
 
-public class StreamingService extends IntentService {
+public class StreamingService extends Service {
 
     private static final String TAG = "StreamingService";
     public static final String SERVE_PATH_ARG = "ca.pkay.rcexplorer.streaming_service.arg1";
@@ -38,109 +38,126 @@ public class StreamingService extends IntentService {
     private final String CHANNEL_NAME = "Streaming service";
     private final int PERSISTENT_NOTIFICATION_ID = 179;
     private Rclone rclone;
-    private Process runningProcess;
-
-    /**
-     * Creates an IntentService.  Invoked by your subclass's constructor.*
-     */
-    public StreamingService() {
-        super("ca.pkay.rcexplorer.streamingservice");
-    }
+    private volatile Process runningProcess;
+    private Thread serveThread;
 
     @Override
     public void onCreate() {
         super.onCreate();
-        setNotificationChannel();
-        rclone = new Rclone(this);
-    }
-
-    @Override
-    protected void onHandleIntent(@Nullable Intent intent) {
-        if (intent == null) {
-            return;
-        }
-        final String servePath = intent.getStringExtra(SERVE_PATH_ARG);
-        final RemoteItem remote = intent.getParcelableExtra(REMOTE_ARG);
-        final Boolean showNotificationText = intent.getBooleanExtra(SHOW_NOTIFICATION_TEXT, false);
-        final int protocol = intent.getIntExtra(SERVE_PROTOCOL, SERVE_HTTP);
-        final int port = intent.getIntExtra(SERVE_PORT, 8080);
-        final Boolean allowRemoteAccess = intent.getBooleanExtra(ALLOW_REMOTE_ACCESS, false);
-        final String authenticationUsername = intent.getStringExtra(AUTHENTICATION_USERNAME);
-        final String authenticationPassword = intent.getStringExtra(AUTHENTICATION_PASSWORD);
-
-        int flags = 0;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            flags = PendingIntent.FLAG_IMMUTABLE;
-        }
-        Intent foregroundIntent = new Intent(this, StreamingService.class);
-        PendingIntent pendingIntent = PendingIntent.getActivity(this, 0, foregroundIntent, flags);
-
-        Intent cancelIntent = new Intent(this, ServeCancelAction.class);
-        PendingIntent cancelPendingIntent = PendingIntent.getBroadcast(this, 0, cancelIntent, flags);
-
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
-                .setSmallIcon(R.drawable.ic_streaming)
-                .setContentTitle(getString(R.string.streaming_service_notification_title))
-                .setPriority(NotificationCompat.PRIORITY_LOW)
-                .setContentIntent(pendingIntent)
-                .addAction(R.drawable.ic_cancel_download, getString(R.string.cancel), cancelPendingIntent);
-
-        if (showNotificationText) {
-            Uri uri = Uri.parse("http://127.0.0.1:" + port);
-            Intent webPageIntent = new Intent(Intent.ACTION_VIEW, uri);
-            webPageIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-            PendingIntent webPagePendingIntent = PendingIntent.getActivity(this, 0, webPageIntent, flags);
-            builder.setContentIntent(webPagePendingIntent);
-            builder.setContentText(getString(R.string.streaming_service_notification_content, port));
-        }
-
-        startForeground(PERSISTENT_NOTIFICATION_ID, builder.build());
-
-        switch (protocol) {
-            case SERVE_FTP:
-                runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_FTP, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
-                break;
-            case SERVE_WEBDAV:
-                runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_WEBDAV, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
-                break;
-            case SERVE_DLNA:
-                runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_DLNA, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
-                break;
-            case SERVE_HTTP:
-            default:
-                runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_HTTP, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
-                break;
-        }
-
-        if (runningProcess != null) {
-            try {
-                runningProcess.waitFor();
-            } catch (InterruptedException e) {
-                FLog.e(TAG, "onHandleIntent: error waiting for process", e);
-            }
-        }
-
-        if (runningProcess != null && runningProcess.exitValue() != 0) {
-            rclone.logErrorOutput(runningProcess);
-        }
-
-        stopForeground(true);
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-        if (null != runningProcess) {
-            runningProcess.destroy();
-        }
-    }
-
-    private void setNotificationChannel() {
         NotificationUtils.createNotificationChannel(this,
                 CHANNEL_ID,
                 CHANNEL_NAME,
                 NotificationManager.IMPORTANCE_LOW,
                 getString(R.string.streaming_service_notification_channel_description)
         );
+        rclone = new Rclone(this);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        if (intent == null) {
+            stopSelf();
+            return START_NOT_STICKY;
+        }
+
+        final String servePath = intent.getStringExtra(SERVE_PATH_ARG);
+        final RemoteItem remote = intent.getParcelableExtra(REMOTE_ARG);
+        final boolean showNotificationText = intent.getBooleanExtra(SHOW_NOTIFICATION_TEXT, false);
+        final int protocol = intent.getIntExtra(SERVE_PROTOCOL, SERVE_HTTP);
+        final int port = intent.getIntExtra(SERVE_PORT, 8080);
+        final boolean allowRemoteAccess = intent.getBooleanExtra(ALLOW_REMOTE_ACCESS, false);
+        final String authenticationUsername = intent.getStringExtra(AUTHENTICATION_USERNAME);
+        final String authenticationPassword = intent.getStringExtra(AUTHENTICATION_PASSWORD);
+
+        int pendingFlags = 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            pendingFlags = PendingIntent.FLAG_IMMUTABLE;
+        }
+
+        Intent cancelIntent = new Intent(this, ServeCancelAction.class);
+        PendingIntent cancelPendingIntent = PendingIntent.getBroadcast(this, 0, cancelIntent, pendingFlags);
+
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(this, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_streaming)
+                .setContentTitle(getString(R.string.streaming_service_notification_title))
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .addAction(R.drawable.ic_cancel_download, getString(R.string.cancel), cancelPendingIntent);
+
+        if (showNotificationText) {
+            Uri uri = Uri.parse("http://127.0.0.1:" + port);
+            Intent webPageIntent = new Intent(Intent.ACTION_VIEW, uri);
+            webPageIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+            PendingIntent webPagePendingIntent = PendingIntent.getActivity(this, 0, webPageIntent, pendingFlags);
+            builder.setContentIntent(webPagePendingIntent);
+            builder.setContentText(getString(R.string.streaming_service_notification_content, port));
+        }
+
+        // Promote to foreground immediately on the main thread — this is critical on GrapheneOS
+        // and Android 12+ where the 5-second window is strictly enforced. IntentService called
+        // startForeground() from a background thread, causing the service to be killed before
+        // promotion on stricter OS variants.
+        startForeground(PERSISTENT_NOTIFICATION_ID, builder.build());
+
+        stopServeProcess();
+
+        serveThread = new Thread(() -> {
+            switch (protocol) {
+                case SERVE_FTP:
+                    runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_FTP, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
+                    break;
+                case SERVE_WEBDAV:
+                    runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_WEBDAV, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
+                    break;
+                case SERVE_DLNA:
+                    runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_DLNA, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
+                    break;
+                case SERVE_HTTP:
+                default:
+                    runningProcess = rclone.serve(Rclone.SERVE_PROTOCOL_HTTP, port, allowRemoteAccess, authenticationUsername, authenticationPassword, remote, servePath);
+                    break;
+            }
+
+            if (runningProcess != null) {
+                try {
+                    runningProcess.waitFor();
+                } catch (InterruptedException e) {
+                    FLog.e(TAG, "serve thread interrupted while waiting for process", e);
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            if (runningProcess != null && runningProcess.exitValue() != 0) {
+                rclone.logErrorOutput(runningProcess);
+            }
+
+            stopForeground(true);
+            stopSelf();
+        });
+        serveThread.start();
+
+        return START_NOT_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        stopServeProcess();
+        super.onDestroy();
+    }
+
+    @Nullable
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null;
+    }
+
+    private void stopServeProcess() {
+        if (runningProcess != null) {
+            runningProcess.destroy();
+            runningProcess = null;
+        }
+        if (serveThread != null) {
+            serveThread.interrupt();
+            serveThread = null;
+        }
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/util/ActivityHelper.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/util/ActivityHelper.java
@@ -6,6 +6,7 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.res.Configuration;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.TypedValue;
@@ -96,6 +97,18 @@ public class ActivityHelper {
             context.startService(intent);
         } catch (IllegalStateException e) {
             FLog.e(TAG, "Host context state is invalid, not starting service", e);
+        }
+    }
+
+    public static void tryStartForegroundService(@NonNull Context context, @NonNull Intent intent) {
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent);
+            } else {
+                context.startService(intent);
+            }
+        } catch (IllegalStateException e) {
+            FLog.e(TAG, "Host context state is invalid, not starting foreground service", e);
         }
     }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/EphemeralWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/EphemeralWorker.kt
@@ -87,6 +87,10 @@ class EphemeralWorker (private var mContext: Context, workerParams: WorkerParame
 
     override fun doWork(): Result {
 
+        if (sIsLoggingEnabled) {
+            log2File = Log2File(mContext)
+        }
+
         registerBroadcastReceivers()
 
         updateForegroundNotification(mNotificationManager?.updateNotification(

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -90,6 +90,10 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
 
     override fun doWork(): Result {
 
+        if (sIsLoggingEnabled) {
+            log2File = Log2File(mContext)
+        }
+
         prepareNotifications()
         registerBroadcastReceivers()
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -129,6 +129,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
             handleTask()
             postSync()
         } else {
+            failureReason = FAILURE_REASON.NO_TASK
             postSync()
             return Result.failure()
         }
@@ -181,6 +182,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         if (sRcloneProcess != null) {
             val localProcessReference = sRcloneProcess!!
             val infoLines = StringBuilder()
+            var lastStats = ""
             try {
                 val reader = BufferedReader(InputStreamReader(localProcessReference.errorStream))
                 val iterator = reader.lineSequence().iterator()
@@ -205,6 +207,12 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                                     infoLines.append(msg).append("\n")
                                 }
                             }
+                            "notice" -> {
+                                val msg = logline.optString("msg", "")
+                                if (msg.isNotEmpty()) {
+                                    lastStats = msg
+                                }
+                            }
                         }
 
                         updateForegroundNotification(mNotificationManager.updateSyncNotification(
@@ -224,8 +232,15 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
             } catch (e: IOException) {
                 FLog.e(TAG, "onHandleIntent: error reading stdout", e)
             }
-            if (infoLines.isNotEmpty()) {
-                SyncLog.info(mContext, mTitle, infoLines.toString().trimEnd())
+            val detail = buildString {
+                if (infoLines.isNotEmpty()) append(infoLines.trimEnd())
+                if (lastStats.isNotEmpty()) {
+                    if (isNotEmpty()) append("\n\n")
+                    append(lastStats)
+                }
+            }
+            if (detail.isNotEmpty()) {
+                SyncLog.info(mContext, mTitle, detail)
             }
             try {
                 localProcessReference.waitFor()
@@ -252,7 +267,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         when (failureReason) {
             FAILURE_REASON.NO_FAILURE -> {
                 showSuccessNotification(notificationId)
-                followupTask(mTask.onSuccessFollowup)
+                if (::mTask.isInitialized) followupTask(mTask.onSuccessFollowup)
                 return
             }
             FAILURE_REASON.CANCELLED -> {
@@ -276,7 +291,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 content = mContext.getString(R.string.operation_failed_unknown_rclone_error, mTitle)
             }
         }
-        followupTask(mTask.onFailFollowup)
+        if (::mTask.isInitialized) followupTask(mTask.onFailFollowup)
         showFailNotification(notificationId, content)
         endNotificationAlreadyPosted = true
         finishWork()

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -180,6 +180,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         SyncLog.info(mContext, mTitle, mContext.getString(R.string.operation_start_sync))
         if (sRcloneProcess != null) {
             val localProcessReference = sRcloneProcess!!
+            val infoLines = StringBuilder()
             try {
                 val reader = BufferedReader(InputStreamReader(localProcessReference.errorStream))
                 val iterator = reader.lineSequence().iterator()
@@ -188,13 +189,22 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                     try {
                         val logline = JSONObject(line)
                         //todo: migrate this to StatusObject, so that we can handle everything properly.
-                        if (logline.getString("level") == "error") {
-                            if (sIsLoggingEnabled) {
-                                log2File?.log(line)
+                        when (logline.getString("level")) {
+                            "error" -> {
+                                if (sIsLoggingEnabled) {
+                                    log2File?.log(line)
+                                }
+                                statusObject.parseLoglineToStatusObject(logline)
                             }
-                            statusObject.parseLoglineToStatusObject(logline)
-                        } else if (logline.getString("level") == "warning") {
-                            statusObject.parseLoglineToStatusObject(logline)
+                            "warning" -> {
+                                statusObject.parseLoglineToStatusObject(logline)
+                            }
+                            "info" -> {
+                                val msg = logline.optString("msg", "")
+                                if (msg.isNotEmpty()) {
+                                    infoLines.append(msg).append("\n")
+                                }
+                            }
                         }
 
                         updateForegroundNotification(mNotificationManager.updateSyncNotification(
@@ -213,6 +223,9 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 FLog.e(TAG, "onHandleIntent: I/O interrupted, stream closed", e)
             } catch (e: IOException) {
                 FLog.e(TAG, "onHandleIntent: error reading stdout", e)
+            }
+            if (infoLines.isNotEmpty()) {
+                SyncLog.info(mContext, mTitle, infoLines.toString().trimEnd())
             }
             try {
                 localProcessReference.waitFor()


### PR DESCRIPTION
## Problem

Six bugs fixed in this PR, found and fixed while getting Round-Sync working reliably on GrapheneOS against a Synology SFTP remote.

---

### Fix 1: StreamingService killed immediately on GrapheneOS

On GrapheneOS (and any Android variant with strict foreground service enforcement), the streaming / file-browser feature does not work. The `rclone serve http` process starts but is killed within 2–30 seconds before the WebView can load the file listing.

**Root cause:** `StreamingService` extended the deprecated `IntentService`. `startForeground()` was called from a background worker thread (`onHandleIntent`), not from the main thread in `onStartCommand`. Android requires `startForeground()` within 5 seconds of `startForegroundService()`. On GrapheneOS this window was consistently missed.

**Fix:**
- Convert `StreamingService` from `IntentService` to `Service`
- Call `startForeground()` immediately in `onStartCommand()` on the main thread
- Run blocking `waitFor()` in a dedicated thread; return `START_NOT_STICKY`
- Add `tryStartForegroundService()` to `ActivityHelper`; use it for all `StreamingService` start calls

---

### Fix 2: Settings import crashes on backups without a `filters` array

`Importer.createFilterList()` called `reader.getJSONArray("filters")` which throws `JSONException` when the key is absent. The `filters` array was added later and is missing from all pre-existing exports (including the current F-Droid release v2.5.6). This exception aborted the entire import — rclone.conf was already written but tasks and preferences were silently skipped.

**Fix:** Replace `getJSONArray()` with `optJSONArray()` + null-check for `filters`, `tasks`, and `trigger` arrays in `Importer.java`.

---

### Fix 3: `log2File` never initialized in `SyncWorker`/`EphemeralWorker`

Follow-up to Fix 2 — after fixing import, sync logging (`log2File`) was never initialized in these two workers, so sync log entries were silently dropped in some code paths.

---

### Fix 4: rclone INFO output not visible in the in-app sync log

rclone's own progress/status output (transferred bytes, errors, "nothing to do", etc.) wasn't being captured into the in-app sync log, making it hard to diagnose sync issues from within the app. Now captured at INFO level.

---

### Fix 5: SFTP sync fails on restricted shells + `-vvv`/`--log-level` conflict

Two related SFTP/logging issues:
- Synology (and similar) restricted SSH shells can't run `md5sum`/`sha1sum` over SSH even though the files are reachable via SFTP, causing `corrupted on transfer: hashes differ` failures on every transfer. Fixed by setting `--sftp-md5sum-command none --sftp-sha1sum-command none` for SFTP remotes.
- When debug logging is enabled, `-vvv` was being combined with `--log-level INFO`, which rclone rejects (`Can't set -v and --log-level`), causing rclone to exit immediately with no useful output.

---

### Fix 6: Changed files silently skipped by sync — two compounding bugs

Reported symptom: sync appeared to detect changes "only by file size, not by date" — files with the same size that had genuinely changed content were never re-synced.

**Bug 6a:** Fix 5's `--sftp-md5sum-command none` combined with `--checksum` (set when "use checksum" is enabled on a task) left rclone with no common hash type to compare. rclone silently fell back to a size-only comparison. Fixed by not setting `--checksum` for SFTP remotes — rclone then uses its default size+modtime comparison instead.

**Bug 6b (the actual root cause):** `RCLONE_LOCAL_NO_SET_MODTIME=true` has been set for *every* rclone invocation since 2021 (to avoid old `chtimes` crashes, ref [rclone#2446](https://github.com/rclone/rclone/issues/2446)). In current rclone this makes the local backend's `Precision()` report `ModTimeNotSupported` unconditionally, which makes rclone's default comparison treat any same-size file as unchanged — skipping modification-time comparison entirely, for *every* task regardless of remote type or checksum setting. Verified in the vendored rclone v1.71.0 source that a failing `chtimes()`/`SetModTime` is not fatal (just logged and counted, transfer still succeeds), so the 2021 workaround is no longer needed and was silently breaking change detection. Removed from both `Rclone.java` and `RcloneRcd.java`.

Both 6a and 6b were verified against a live Synology SFTP remote: a same-size, content-changed file is now correctly detected via modtime and re-transferred, a second sync correctly no-ops once genuinely in sync, and the local destination's mtime is now correctly set to match the source with no `chtimes` errors logged.

---

## Test plan

- [x] File browser / streaming works on GrapheneOS Pixel without serve process dying (emulator-verified, GrapheneOS hardware test still pending)
- [ ] Cancel notification button still stops the serve process
- [x] Settings export from v2.5.6 F-Droid release imports successfully into patched build
- [x] Tasks and rclone.conf are imported correctly from backup ZIP
- [x] SFTP sync against Synology restricted shell no longer fails with "corrupted on transfer"
- [x] Same-size, content-changed file on SFTP remote is now correctly re-synced (verified live, both with and without "use checksum" enabled)
- [x] Unchanged files are not needlessly re-transferred on subsequent syncs
- [ ] No regression on stock Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)
