### PR TITLE
fix: don't crash import when backup has no filters/tasks/triggers array

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Importer.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Database/json/Importer.java
@@ -33,7 +33,10 @@ public class Importer {
     public static ArrayList<Trigger> createTriggerlist(String content) throws JSONException {
         ArrayList<Trigger> result = new ArrayList<>();
         JSONObject reader = new JSONObject(content);
-        JSONArray array = reader.getJSONArray("trigger");
+        JSONArray array = reader.optJSONArray("trigger");
+        if (array == null) {
+            return result;
+        }
         for (int i = 0; i < array.length(); i++) {
             JSONObject triggerObject = array.getJSONObject(i);
             result.add(Trigger.Companion.fromString(triggerObject.toString()));
@@ -44,7 +47,10 @@ public class Importer {
     public static ArrayList<Task> createTasklist(String content) throws JSONException {
         ArrayList<Task> result = new ArrayList<>();
         JSONObject reader = new JSONObject(content);
-        JSONArray array = reader.getJSONArray("tasks");
+        JSONArray array = reader.optJSONArray("tasks");
+        if (array == null) {
+            return result;
+        }
         for (int i = 0; i < array.length(); i++) {
             JSONObject taskObject = array.getJSONObject(i);
             result.add(Task.Companion.fromString(taskObject.toString()));
@@ -54,7 +60,10 @@ public class Importer {
     public static ArrayList<Filter> createFilterList(String content) throws JSONException {
         ArrayList<Filter> result = new ArrayList<>();
         JSONObject reader = new JSONObject(content);
-        JSONArray array = reader.getJSONArray("filters");
+        JSONArray array = reader.optJSONArray("filters");
+        if (array == null) {
+            return result;
+        }
         for (int i = 0; i < array.length(); i++) {
             JSONObject filterObject = array.getJSONObject(i);
             result.add(Filter.Companion.fromString(filterObject.toString()));


### PR DESCRIPTION
Split out of #406 per reviewer request (separate unrelated fixes into their own PRs).

## Bug

`Importer.createFilterList()` (and the equivalent task/trigger readers) call `reader.getJSONArray("filters")`, which throws `JSONException` when the key is absent from the JSON. Backups exported by older app versions don't contain a `filters` array (it was added later), so importing such a backup throws partway through `Importer.importJson()` and aborts the entire import — remotes get written, but tasks/preferences never do. This matches the symptom reported in review of #406 ("remotes populated but no tasks imported"), which the reviewer confirmed as reproducible.

## Fix

Replace `getJSONArray()` with `optJSONArray()` for `filters`, `tasks`, and `trigger`, returning an empty list when the key is missing, so a backup missing a newer field still imports the sections that are present instead of aborting entirely.

## Reproduction

- Take (or construct) a backup export JSON that has no top-level `filters` key (e.g. any backup made before filters were added, or a hand-edited JSON with that key removed).
- Import it via Settings → Import.
- Before this fix: import throws a `JSONException` inside `createFilterList()`, the whole import aborts — remotes/rclone.conf get written but tasks and other settings are silently never imported.
- After this fix: import completes for all sections present in the backup.

## Test plan

- [x] Local build compiles (`./gradlew :app:compileOssDebugSources`).
- [ ] Import a legacy backup JSON without a `filters` key and confirm tasks/preferences now import correctly.