### PR TITLE
fix: stop forcing size-only sync comparisons via RCLONE_LOCAL_NO_SET_MODTIME

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -181,9 +181,17 @@ public class Rclone {
         String tmpDir = context.getCacheDir().getAbsolutePath();
         environmentValues.add("TMPDIR=" + tmpDir);
 
-        // ignore chtimes errors
-        // ref: https://github.com/rclone/rclone/issues/2446
-        environmentValues.add("RCLONE_LOCAL_NO_SET_MODTIME=true");
+        // RCLONE_LOCAL_NO_SET_MODTIME used to be set here to work around chtimes
+        // crashes on old Android storage stacks (ref: rclone#2446). It makes the
+        // local backend's Precision() report ModTimeNotSupported unconditionally
+        // (backend/local/local.go), which makes rclone's default file comparison
+        // fall back to a silent size-only check for every sync, ignoring
+        // modification time entirely -- changed files of the same size never get
+        // re-synced. A failing chtimes() is not fatal in current rclone: a failed
+        // SetModTime is just logged and counted as an error, the transfer itself
+        // still succeeds (fs/operations/operations.go). So leave modtime-setting
+        // enabled and let rclone's own runtime precision probe (readPrecision())
+        // degrade gracefully per-remote if chtimes truly isn't supported there.
 
         // Allow the caller to overwrite any option for special cases
         Iterator<String> envVarIter = environmentValues.iterator();

--- a/app/src/main/java/ca/pkay/rcloneexplorer/RcloneRcd.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/RcloneRcd.java
@@ -170,9 +170,9 @@ public class RcloneRcd {
         String tmpDir = context.getCacheDir().getAbsolutePath();
         environmentValues.add("TMPDIR=" + tmpDir);
 
-        // ignore chtimes errors
-        // ref: https://github.com/rclone/rclone/issues/2446
-        environmentValues.add("RCLONE_LOCAL_NO_SET_MODTIME=true");
+        // See Rclone.java getRcloneEnv() for why RCLONE_LOCAL_NO_SET_MODTIME is
+        // deliberately not set here: it forces rclone's local-backend file
+        // comparison to silently ignore modification time (size-only fallback).
         return environmentValues.toArray(new String[0]);
     }
 


### PR DESCRIPTION
Split out of #406 per reviewer request (separate unrelated fixes into their own PRs).

## Bug

`RCLONE_LOCAL_NO_SET_MODTIME=true` has been set for every rclone invocation since 2021 (`f43949be`), to work around chtimes crashes on old Android storage stacks ([rclone#2446](https://github.com/rclone/rclone/issues/2446)). It has a much bigger side effect than intended: rclone's local backend `Precision()` reports `fs.ModTimeNotSupported` unconditionally whenever `NoSetModTime` is set (`backend/local/local.go`), and rclone's default file comparison treats `ModTimeNotSupported` as "always equal" as soon as file sizes match (`fs/operations/operations.go`) — modification-time comparison is skipped entirely. Every sync, regardless of remote type or `--checksum`, silently degrades to a same-size-means-unchanged check. Changed files that happen to keep the same size are never re-synced.

## Fix

Verified in current rclone (v1.71.0, vendored in this repo) that a failing `chtimes()`/`SetModTime` is **not** fatal: `fs/operations/operations.go` just logs and counts the error, the transfer itself still succeeds. The 2021 workaround for the old crash is no longer needed and was silently breaking change detection instead. Remove `RCLONE_LOCAL_NO_SET_MODTIME=true` from both `Rclone.java` and `RcloneRcd.java`, letting rclone's own runtime precision probe handle it per-remote.

## Reproduction

- Any remote (tested against SFTP/Synology): sync a file once so source and destination match.
- Edit the file so its **size stays exactly the same** but content and mtime change (e.g. flip one character).
- Trigger sync again.
- Before this fix: `sync.log` shows the file is skipped ("Sizes identical" / unchanged) — the change is never picked up.
- After this fix: file is correctly detected as changed via modtime and re-transferred ("Copied (replaced existing)"); a subsequent sync then correctly no-ops.

## Test plan

- [x] Verified end-to-end against a live Synology SFTP remote and on a physical Pixel 7a (GrapheneOS): same-size/changed-content file is now correctly detected and re-transferred, no `chtimes` errors logged, local mtime ends up matching the source.
- [x] Local build compiles (`./gradlew :app:compileOssDebugSources`).