### PR TITLE
fix: enable in-app sync logging (log2File init, INFO/NOTICE capture, log-level conflict)

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/Log2File.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Log2File.java
@@ -22,6 +22,10 @@ public class Log2File {
 
     public void log(String message) {
         File path = context.getExternalFilesDir("logs");
+        if (path == null) {
+            FLog.e(TAG, "log: external storage not available, cannot write log");
+            return;
+        }
         File logFile = new File(path, "log.txt");
 
         clearLogsIfTooBif(logFile);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -688,7 +688,13 @@ public class Rclone {
         String localRemotePath = (remoteItem.isRemoteType(RemoteItem.LOCAL)) ? getLocalRemotePathPrefix(remoteItem, context)  + "/" : "";
         String remoteSection = (remotePath.compareTo("//" + remoteName) == 0) ? remoteName + ":" + localRemotePath : remoteName + ":" + localRemotePath + remotePath;
 
-        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--stats-log-level", "NOTICE", "--log-level", "INFO", "--use-json-log"));
+        boolean loggingEnabled = PreferenceManager
+                .getDefaultSharedPreferences(context)
+                .getBoolean(context.getString(R.string.pref_key_logs), false);
+        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--use-json-log"));
+        if (!loggingEnabled) {
+            defaultParameter.addAll(Arrays.asList("--stats-log-level", "NOTICE", "--log-level", "INFO"));
+        }
         ArrayList<String> directionParameter = new ArrayList<>();
 
         if(useMD5Sum){

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Rclone.java
@@ -688,7 +688,7 @@ public class Rclone {
         String localRemotePath = (remoteItem.isRemoteType(RemoteItem.LOCAL)) ? getLocalRemotePathPrefix(remoteItem, context)  + "/" : "";
         String remoteSection = (remotePath.compareTo("//" + remoteName) == 0) ? remoteName + ":" + localRemotePath : remoteName + ":" + localRemotePath + remotePath;
 
-        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--stats-log-level", "NOTICE", "--use-json-log"));
+        ArrayList<String> defaultParameter = new ArrayList<>(Arrays.asList("--transfers", "1", "--stats=1s", "--stats-log-level", "NOTICE", "--log-level", "INFO", "--use-json-log"));
         ArrayList<String> directionParameter = new ArrayList<>();
 
         if(useMD5Sum){

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/EphemeralWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/EphemeralWorker.kt
@@ -87,6 +87,10 @@ class EphemeralWorker (private var mContext: Context, workerParams: WorkerParame
 
     override fun doWork(): Result {
 
+        if (sIsLoggingEnabled) {
+            log2File = Log2File(mContext)
+        }
+
         registerBroadcastReceivers()
 
         updateForegroundNotification(mNotificationManager?.updateNotification(

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -90,6 +90,10 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
 
     override fun doWork(): Result {
 
+        if (sIsLoggingEnabled) {
+            log2File = Log2File(mContext)
+        }
+
         prepareNotifications()
         registerBroadcastReceivers()
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -181,6 +181,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         if (sRcloneProcess != null) {
             val localProcessReference = sRcloneProcess!!
             val infoLines = StringBuilder()
+            var lastStats = ""
             try {
                 val reader = BufferedReader(InputStreamReader(localProcessReference.errorStream))
                 val iterator = reader.lineSequence().iterator()
@@ -205,6 +206,12 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                                     infoLines.append(msg).append("\n")
                                 }
                             }
+                            "notice" -> {
+                                val msg = logline.optString("msg", "")
+                                if (msg.isNotEmpty()) {
+                                    lastStats = msg
+                                }
+                            }
                         }
 
                         updateForegroundNotification(mNotificationManager.updateSyncNotification(
@@ -224,8 +231,15 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
             } catch (e: IOException) {
                 FLog.e(TAG, "onHandleIntent: error reading stdout", e)
             }
-            if (infoLines.isNotEmpty()) {
-                SyncLog.info(mContext, mTitle, infoLines.toString().trimEnd())
+            val detail = buildString {
+                if (infoLines.isNotEmpty()) append(infoLines.trimEnd())
+                if (lastStats.isNotEmpty()) {
+                    if (isNotEmpty()) append("\n\n")
+                    append(lastStats)
+                }
+            }
+            if (detail.isNotEmpty()) {
+                SyncLog.info(mContext, mTitle, detail)
             }
             try {
                 localProcessReference.waitFor()

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -180,6 +180,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         SyncLog.info(mContext, mTitle, mContext.getString(R.string.operation_start_sync))
         if (sRcloneProcess != null) {
             val localProcessReference = sRcloneProcess!!
+            val infoLines = StringBuilder()
             try {
                 val reader = BufferedReader(InputStreamReader(localProcessReference.errorStream))
                 val iterator = reader.lineSequence().iterator()
@@ -188,13 +189,22 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                     try {
                         val logline = JSONObject(line)
                         //todo: migrate this to StatusObject, so that we can handle everything properly.
-                        if (logline.getString("level") == "error") {
-                            if (sIsLoggingEnabled) {
-                                log2File?.log(line)
+                        when (logline.getString("level")) {
+                            "error" -> {
+                                if (sIsLoggingEnabled) {
+                                    log2File?.log(line)
+                                }
+                                statusObject.parseLoglineToStatusObject(logline)
                             }
-                            statusObject.parseLoglineToStatusObject(logline)
-                        } else if (logline.getString("level") == "warning") {
-                            statusObject.parseLoglineToStatusObject(logline)
+                            "warning" -> {
+                                statusObject.parseLoglineToStatusObject(logline)
+                            }
+                            "info" -> {
+                                val msg = logline.optString("msg", "")
+                                if (msg.isNotEmpty()) {
+                                    infoLines.append(msg).append("\n")
+                                }
+                            }
                         }
 
                         updateForegroundNotification(mNotificationManager.updateSyncNotification(
@@ -213,6 +223,9 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 FLog.e(TAG, "onHandleIntent: I/O interrupted, stream closed", e)
             } catch (e: IOException) {
                 FLog.e(TAG, "onHandleIntent: error reading stdout", e)
+            }
+            if (infoLines.isNotEmpty()) {
+                SyncLog.info(mContext, mTitle, infoLines.toString().trimEnd())
             }
             try {
                 localProcessReference.waitFor()


### PR DESCRIPTION
Split out of #406 per reviewer request (separate unrelated fixes into their own PRs). This bundles the sync-logging pipeline fixes together since they're one coherent feature evolution — splitting the log-level fix out on its own would leave an intermediate state that crashes (see below), which is the same pattern the reviewer already flagged for the SFTP PR.

## Bugs

1. **`log2File` never initialized.** `log2File: Log2File? = null` in `SyncWorker.kt`/`EphemeralWorker.kt` was declared but never assigned, so `log2File?.log()` was always a no-op even with "Use Logs" enabled — `logs/log.txt` stayed empty. Also added a null guard in `Log2File` for `getExternalFilesDir()` returning null (observed on GrapheneOS).
2. **rclone ran at default log level**, so INFO messages (per-file operations, "There was nothing to transfer") never reached the in-app sync log — only NOTICE-level summary stats. Added `--log-level INFO` and collected INFO lines into the sync log entry.
3. **(1)+(2) combined caused a silent crash**: adding `--log-level INFO` unconditionally conflicts with `-vvv` (added when debug logging is enabled) — rclone exits immediately with `Can't set -v and --log-level`, and the sync silently does nothing. Fixed by only adding `--log-level`/`--stats-log-level` when verbose logging is off.
4. Also captured NOTICE-level output (transfer stats) alongside INFO messages in the same sync log entry, since transfer stats were previously dropped from the in-app log entirely.

## Reproduction

- Enable "Use Logs" in settings and run any sync.
- Before this fix: `logs/log.txt` stays empty regardless of sync outcome; the in-app sync log entry contains no per-file detail; if debug logging is on, sync fails silently with no useful log output at all (the `-vvv`/`--log-level` crash).
- After this fix: `logs/log.txt` is populated for error-level rclone output, the sync log entry includes per-file INFO lines plus a final NOTICE transfer-stats line, and sync no longer crashes when debug logging is enabled.

## Test plan

- [x] Local build compiles (`./gradlew :app:compileOssDebugSources`).
- [ ] Run a sync with "Use Logs" enabled and confirm the in-app sync log shows per-file detail + transfer stats, and `logs/log.txt` captures error-level output.