### PR TITLE
fix: guard postSync() against uninitialized mTask

### DIFF
--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -125,6 +125,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
             handleTask()
             postSync()
         } else {
+            failureReason = FAILURE_REASON.NO_TASK
             postSync()
             return Result.failure()
         }
@@ -235,7 +236,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         when (failureReason) {
             FAILURE_REASON.NO_FAILURE -> {
                 showSuccessNotification(notificationId)
-                followupTask(mTask.onSuccessFollowup)
+                if (::mTask.isInitialized) followupTask(mTask.onSuccessFollowup)
                 return
             }
             FAILURE_REASON.CANCELLED -> {
@@ -259,7 +260,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 content = mContext.getString(R.string.operation_failed_unknown_rclone_error, mTitle)
             }
         }
-        followupTask(mTask.onFailFollowup)
+        if (::mTask.isInitialized) followupTask(mTask.onFailFollowup)
         showFailNotification(notificationId, content)
         endNotificationAlreadyPosted = true
         finishWork()


### PR DESCRIPTION
Split out of #406 per reviewer request (separate unrelated fixes into their own PRs).

## Bug

`WorkManager` can dispatch a follow-up `SyncWorker` run for which the task lookup finds nothing (e.g. task id `0`, or the task was deleted between scheduling and execution). `doWork()` then takes the "no task" branch and `mTask` (a `lateinit var`) is never assigned. `postSync()` unconditionally reads `mTask.onSuccessFollowup` / `mTask.onFailFollowup` in both the success and failure paths, which throws `UninitializedPropertyAccessException` and crashes the worker.

## Fix

Guard both follow-up-task calls in `postSync()` with `if (::mTask.isInitialized)`, and set `failureReason = FAILURE_REASON.NO_TASK` in the "no task" branch of `doWork()` so the correct failure notification/reason is surfaced instead of falling through to the default "unknown" failure content.

## Reproduction

- Trigger a `SyncWorker` run with no resolvable task, e.g. via the exported broadcast receiver with an invalid/stale task id:
  ```bash
  adb shell am broadcast -n <pkg>/ca.pkay.rcloneexplorer.BroadcastReceivers.SyncRestartAction --el task 0
  ```
- Before this fix: worker crashes with `UninitializedPropertyAccessException` in `postSync()`.
- After this fix: worker completes cleanly and shows the "no task" failure notification.

## Test plan

- [x] Local build compiles (`./gradlew :app:compileOssDebugSources`).
- [ ] Trigger a sync broadcast with an invalid task id and confirm no crash, correct failure notification shown.