### PR TITLE
Handle rclone sync errors in task results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ debug/
 .idea/codeStyles/codeStyleConfig.xml
 .idea/inspectionProfiles/Project_Default.xml
 .idea/
+
+# exported app backup from Android studio
+**/application.backup

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/MainActivity.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/MainActivity.java
@@ -233,6 +233,7 @@ public class MainActivity extends AppCompatActivity
     protected void onNewIntent(Intent intent) {
         super.onNewIntent(intent);
         setIntent(intent);
+        // MainActivity is singleTop, so notification taps can arrive here instead of onCreate().
         if(MAIN_ACTIVITY_START_LOG.equals(intent.getAction())){
             startLogFragment();
             navigationView.setCheckedItem(R.id.nav_logs);

--- a/app/src/main/java/ca/pkay/rcloneexplorer/Activities/MainActivity.java
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/Activities/MainActivity.java
@@ -230,6 +230,16 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
+    protected void onNewIntent(Intent intent) {
+        super.onNewIntent(intent);
+        setIntent(intent);
+        if(MAIN_ACTIVITY_START_LOG.equals(intent.getAction())){
+            startLogFragment();
+            navigationView.setCheckedItem(R.id.nav_logs);
+        }
+    }
+
+    @Override
     protected void onPostCreate(@Nullable Bundle savedInstanceState) {
         super.onPostCreate(savedInstanceState);
         requestPermissions();

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/ReportNotifications.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/ReportNotifications.kt
@@ -2,6 +2,7 @@ package ca.pkay.rcloneexplorer.notifications
 
 import android.app.PendingIntent
 import android.app.PendingIntent.FLAG_IMMUTABLE
+import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.content.Context
 import android.content.Intent
 import androidx.core.app.NotificationCompat
@@ -12,6 +13,7 @@ import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import ca.pkay.rcloneexplorer.Activities.MainActivity
 import ca.pkay.rcloneexplorer.BroadcastReceivers.ClearReportBroadcastReciever
 import ca.pkay.rcloneexplorer.R
 import ca.pkay.rcloneexplorer.util.NotificationUtils
@@ -87,9 +89,11 @@ class ReportNotifications(var mContext: Context) {
             .setSmallIcon(R.drawable.ic_twotone_cloud_done_24)
             .setContentTitle(mContext.getString(R.string.operation_report_success_title))
             .setContentText(mContext.getString(R.string.operation_report_success_short_content, notificationContent.lines().size-1))
+            .setContentIntent(createLogsPendingIntent())
+            .setAutoCancel(true)
             .setStyle(
                 NotificationCompat.BigTextStyle().bigText(
-                    notificationContent
+                    content
                 )
             )
             .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -142,9 +146,11 @@ class ReportNotifications(var mContext: Context) {
             .setSmallIcon(R.drawable.ic_twotone_cloud_error_24)
             .setContentTitle(mContext.getString(R.string.operation_report_fail_title))
             .setContentText(mContext.getString(R.string.operation_report_fail_short_content, notificationContent.lines().size-1))
+            .setContentIntent(createLogsPendingIntent())
+            .setAutoCancel(true)
             .setStyle(
                 NotificationCompat.BigTextStyle().bigText(
-                    notificationContent
+                    "$title: $line\n"
                 )
             )
             .setPriority(NotificationCompat.PRIORITY_LOW)
@@ -164,6 +170,17 @@ class ReportNotifications(var mContext: Context) {
             0,
             intent,
             PendingIntent.FLAG_ONE_SHOT or FLAG_IMMUTABLE
+        )
+    }
+
+    private fun createLogsPendingIntent(): PendingIntent {
+        val intent = Intent(mContext, MainActivity::class.java)
+        intent.action = MainActivity.MAIN_ACTIVITY_START_LOG
+        return PendingIntent.getActivity(
+            mContext,
+            0,
+            intent,
+            FLAG_UPDATE_CURRENT or FLAG_IMMUTABLE
         )
     }
 

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/SyncServiceNotifications.kt
@@ -8,6 +8,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.preference.PreferenceManager
 import androidx.work.WorkManager
+import ca.pkay.rcloneexplorer.Activities.MainActivity
 import ca.pkay.rcloneexplorer.BroadcastReceivers.SyncRestartAction
 import ca.pkay.rcloneexplorer.R
 import ca.pkay.rcloneexplorer.util.FLog
@@ -29,6 +30,7 @@ class SyncServiceNotifications(var mContext: Context) {
         const val PERSISTENT_NOTIFICATION_ID_FOR_SYNC = 162
         const val CANCEL_ID_NOTSET = "CANCEL_ID_NOTSET"
         const val TAG = "SyncServiceNotifications"
+        private const val LOGS_PENDING_INTENT_REQUEST = 163
 
     }
 
@@ -83,6 +85,8 @@ class SyncServiceNotifications(var mContext: Context) {
             .setSmallIcon(R.drawable.ic_twotone_cloud_error_24)
             .setContentTitle(mContext.getString(R.string.operation_failed))
             .setContentText(content)
+            .setContentIntent(createLogsPendingIntent())
+            .setAutoCancel(true)
             .setStyle(
                 NotificationCompat.BigTextStyle().bigText(content)
             )
@@ -128,6 +132,8 @@ class SyncServiceNotifications(var mContext: Context) {
             .setSmallIcon(R.drawable.ic_twotone_cloud_error_24)
             .setContentTitle(mContext.getString(R.string.operation_failed_cancelled))
             .setContentText(content)
+            .setContentIntent(createLogsPendingIntent())
+            .setAutoCancel(true)
             .setStyle(
                 NotificationCompat.BigTextStyle().bigText(content)
             )
@@ -166,6 +172,8 @@ class SyncServiceNotifications(var mContext: Context) {
             .setSmallIcon(R.drawable.ic_twotone_cloud_done_24)
             .setContentTitle(mContext.getString(R.string.operation_success, title))
             .setContentText(content)
+            .setContentIntent(createLogsPendingIntent())
+            .setAutoCancel(true)
             .setStyle(
                 NotificationCompat.BigTextStyle().bigText(
                     content
@@ -227,6 +235,7 @@ class SyncServiceNotifications(var mContext: Context) {
                 intent
             )
         }
+        builder.setContentIntent(createLogsPendingIntent())
 
         return builder.build()
     }
@@ -234,5 +243,16 @@ class SyncServiceNotifications(var mContext: Context) {
     fun cancelSyncNotification(notificationId: Int) {
         val notificationManagerCompat = NotificationManagerCompat.from(mContext)
         notificationManagerCompat.cancel(notificationId)
+    }
+
+    private fun createLogsPendingIntent(): PendingIntent {
+        val intent = Intent(mContext, MainActivity::class.java)
+        intent.action = MainActivity.MAIN_ACTIVITY_START_LOG
+        return PendingIntent.getActivity(
+            mContext,
+            LOGS_PENDING_INTENT_REQUEST,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
     }
 }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/support/StatusObject.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/support/StatusObject.kt
@@ -16,9 +16,15 @@ class StatusObject(var mContext: Context){
     var mErrorList = ArrayList<ErrorObject>()
     var mStats = JSONObject()
     var mLogline = JSONObject()
+    private var retryAttemptErrorCount = 0
 
     var estimatedAverageSpeed = 0L
     var lastItemAverageSpeed = 0L
+
+    companion object {
+        private val retryAttemptPattern =
+            Regex("""^Attempt (\d+)/(\d+) failed with (\d+) errors?.*""")
+    }
 
     fun getSpeed(): String {
         return Formatter.formatFileSize(mContext, mStats.optLong("speed", 0)) + "/s"
@@ -63,6 +69,22 @@ class StatusObject(var mContext: Context){
         return mStats.optInt("deletes", 0) + mStats.optInt("deletedDirs", 0)
     }
 
+    fun getRenames(): Int {
+        return mStats.optInt("renames", 0)
+    }
+
+    fun getErrorCount(): Int {
+        return when {
+            retryAttemptErrorCount > 0 -> retryAttemptErrorCount
+            mErrorList.isNotEmpty() -> mErrorList.size
+            else -> mStats.optInt("errors", 0)
+        }
+    }
+
+    fun hasErrors(): Boolean {
+        return getErrorCount() > 0
+    }
+
     fun getErrorMessage(): String {
         if(mLogline.has("msg") && mLogline.getString("level") == "error") {
             return mLogline.getString("msg")
@@ -82,9 +104,23 @@ class StatusObject(var mContext: Context){
             clearObject()
             mLogline = logLine
 
-            var error = ErrorObject(getErrorObject(), getErrorMessage())
+            val retryAttempt = retryAttemptPattern.matchEntire(getErrorMessage())
+            if (retryAttempt != null) {
+                val attempt = retryAttempt.groupValues[1].toInt()
+                val attempts = retryAttempt.groupValues[2].toInt()
+                retryAttemptErrorCount = retryAttempt.groupValues[3].toInt()
+                if (attempt < attempts) {
+                    mErrorList.clear()
+                    retryAttemptErrorCount = 0
+                }
+                return
+            }
+
+            val error = ErrorObject(getErrorObject(), getErrorMessage())
             Log.e(TAG, error.mErrorObject + " - " + error.mErrorMessage)
-            mErrorList.add(error)
+            if (mErrorList.none { it.mErrorObject == error.mErrorObject && it.mErrorMessage == error.mErrorMessage }) {
+                mErrorList.add(error)
+            }
         }
 
         if(logLine.has("stats")) {
@@ -231,7 +267,9 @@ class StatusObject(var mContext: Context){
         var all = ""
         mErrorList.forEach {
             all += it.mErrorMessage + "\n"
-            all += mContext.getString(R.string.status_offendingfile) + it.mErrorObject + "\n"
+            if (it.mErrorObject.isNotEmpty() && !it.mErrorMessage.startsWith("not deleting ")) {
+                all += mContext.getString(R.string.status_offendingfile) + it.mErrorObject + "\n"
+            }
         }
         return all
     }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/notifications/support/StatusObject.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/notifications/support/StatusObject.kt
@@ -109,6 +109,7 @@ class StatusObject(var mContext: Context){
                 val attempt = retryAttempt.groupValues[1].toInt()
                 val attempts = retryAttempt.groupValues[2].toInt()
                 retryAttemptErrorCount = retryAttempt.groupValues[3].toInt()
+                // Rclone repeats the same underlying errors on retries; keep only the final attempt details.
                 if (attempt < attempts) {
                     mErrorList.clear()
                     retryAttemptErrorCount = 0

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncResultFormatter.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncResultFormatter.kt
@@ -1,0 +1,61 @@
+package ca.pkay.rcloneexplorer.workmanager
+
+object SyncResultFormatter {
+    data class Stats(
+        val totalTransfers: Int,
+        val totalSize: String,
+        val deletions: Int,
+        val renames: Int,
+        val errors: Int
+    ) {
+        fun changedItems(): Int = totalTransfers + deletions + renames
+        fun hasErrors(): Boolean = errors > 0
+        fun hasChanges(): Boolean = changedItems() > 0
+    }
+
+    data class Labels(
+        val nothingToDo: String,
+        val completedWithErrors: (Int) -> String,
+        val completed: String,
+        val transferSummary: (String, Int) -> String,
+        val deletionSummary: (Int) -> String,
+        val renameSummary: (Int) -> String
+    )
+
+    fun successMessage(stats: Stats, labels: Labels): String {
+        if (!stats.hasChanges() && !stats.hasErrors()) {
+            return labels.nothingToDo
+        }
+        val lines = summaryLines(stats, labels)
+        return if (lines.isEmpty()) {
+            labels.completed
+        } else {
+            lines.joinToString("\n")
+        }
+    }
+
+    fun completedWithErrorsMessage(stats: Stats, labels: Labels): String {
+        return (listOf(labels.completedWithErrors(stats.errors)) + summaryLines(stats, labels))
+            .joinToString("\n")
+    }
+
+    private fun summaryLines(stats: Stats, labels: Labels): List<String> {
+        val lines = ArrayList<String>()
+
+        if (stats.totalTransfers > 0) {
+            lines.add(labels.transferSummary(stats.totalSize, stats.totalTransfers))
+        } else if (stats.hasChanges()) {
+            lines.add(labels.completed)
+        }
+
+        if (stats.deletions > 0) {
+            lines.add(labels.deletionSummary(stats.deletions))
+        }
+
+        if (stats.renames > 0) {
+            lines.add(labels.renameSummary(stats.renames))
+        }
+
+        return lines
+    }
+}

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncResultFormatter.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncResultFormatter.kt
@@ -3,7 +3,7 @@ package ca.pkay.rcloneexplorer.workmanager
 /**
  * Formats the final sync result from already-collected stats.
  *
- * Example: errors=1, transfers=2 -> "Sync completed with 1 error.\nSuccessfully synced 4 MB in 2 files."
+ * Example: transfers=1, deletions=2 -> "Successfully synced 4 MB in 1 file.\nAlso deleted 2 files/folders."
  */
 object SyncResultFormatter {
     /**
@@ -30,8 +30,8 @@ object SyncResultFormatter {
         val completedWithErrors: (Int) -> String,
         val completed: String,
         val transferSummary: (String, Int) -> String,
-        val deletionSummary: (Int) -> String,
-        val renameSummary: (Int) -> String
+        val deletionSummary: (Int, Boolean) -> String,
+        val renameSummary: (Int, Boolean) -> String
     )
 
     /**
@@ -59,19 +59,22 @@ object SyncResultFormatter {
 
     private fun summaryLines(stats: Stats, labels: Labels): List<String> {
         val lines = ArrayList<String>()
+        var hasActionLine = false
 
         if (stats.totalTransfers > 0) {
             lines.add(labels.transferSummary(stats.totalSize, stats.totalTransfers))
+            hasActionLine = true
         } else if (stats.hasChanges()) {
             lines.add(labels.completed)
         }
 
         if (stats.deletions > 0) {
-            lines.add(labels.deletionSummary(stats.deletions))
+            lines.add(labels.deletionSummary(stats.deletions, hasActionLine))
+            hasActionLine = true
         }
 
         if (stats.renames > 0) {
-            lines.add(labels.renameSummary(stats.renames))
+            lines.add(labels.renameSummary(stats.renames, hasActionLine))
         }
 
         return lines

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncResultFormatter.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncResultFormatter.kt
@@ -1,6 +1,15 @@
 package ca.pkay.rcloneexplorer.workmanager
 
+/**
+ * Formats the final sync result from already-collected stats.
+ *
+ * Example: errors=1, transfers=2 -> "Sync completed with 1 error.\nSuccessfully synced 4 MB in 2 files."
+ */
 object SyncResultFormatter {
+    /**
+     * Final rclone counters used for user-facing summaries. `totalTransfers` is copied or updated files,
+     * while deletions and renames are separate change types.
+     */
     data class Stats(
         val totalTransfers: Int,
         val totalSize: String,
@@ -13,6 +22,9 @@ object SyncResultFormatter {
         fun hasChanges(): Boolean = changedItems() > 0
     }
 
+    /**
+     * Localized message builders supplied by Android resources.
+     */
     data class Labels(
         val nothingToDo: String,
         val completedWithErrors: (Int) -> String,
@@ -22,6 +34,9 @@ object SyncResultFormatter {
         val renameSummary: (Int) -> String
     )
 
+    /**
+     * Clean success message. "Nothing to do" is only valid when there were no changes and no errors.
+     */
     fun successMessage(stats: Stats, labels: Labels): String {
         if (!stats.hasChanges() && !stats.hasErrors()) {
             return labels.nothingToDo
@@ -34,6 +49,9 @@ object SyncResultFormatter {
         }
     }
 
+    /**
+     * Partial result message: keep the clear error state, but still include any work rclone completed.
+     */
     fun completedWithErrorsMessage(stats: Stats, labels: Labels): String {
         return (listOf(labels.completedWithErrors(stats.errors)) + summaryLines(stats, labels))
             .joinToString("\n")

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -348,16 +348,24 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                     transfers
                 )
             },
-            deletionSummary = { deletions ->
+            deletionSummary = { deletions, isAdditional ->
                 mContext.resources.getQuantityString(
-                    R.plurals.operation_success_description_deletions,
+                    if (isAdditional) {
+                        R.plurals.operation_success_description_deletions_also
+                    } else {
+                        R.plurals.operation_success_description_deletions
+                    },
                     deletions,
                     deletions
                 )
             },
-            renameSummary = { renames ->
+            renameSummary = { renames, isAdditional ->
                 mContext.resources.getQuantityString(
-                    R.plurals.operation_success_description_renames,
+                    if (isAdditional) {
+                        R.plurals.operation_success_description_renames_also
+                    } else {
+                        R.plurals.operation_success_description_renames
+                    },
                     renames,
                     renames
                 )

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -345,14 +345,16 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 )
             },
             deletionSummary = { deletions ->
-                mContext.getString(
-                    R.string.operation_success_description_deletions_prefix,
+                mContext.resources.getQuantityString(
+                    R.plurals.operation_success_description_deletions,
+                    deletions,
                     deletions
                 )
             },
             renameSummary = { renames ->
-                mContext.getString(
-                    R.string.operation_success_description_renames_prefix,
+                mContext.resources.getQuantityString(
+                    R.plurals.operation_success_description_renames,
+                    renames,
                     renames
                 )
             }

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -66,7 +66,7 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
     private val mPreferences = PreferenceManager.getDefaultSharedPreferences(mContext)
 
 
-    private var log2File: Log2File? = null
+    private val log2File = Log2File(mContext)
 
 
 
@@ -129,8 +129,11 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
             return Result.failure()
         }
 
-        // Indicate whether the work finished successfully with the Result
-        return Result.success()
+        return if (failureReason == FAILURE_REASON.NO_FAILURE) {
+            Result.success()
+        } else {
+            Result.failure()
+        }
     }
 
     override fun onStopped() {
@@ -183,13 +186,15 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                     val line = iterator.next()
                     try {
                         val logline = JSONObject(line)
+                        val level = logline.optString("level")
+                        if (sIsLoggingEnabled && (level == "error" || level == "warning")) {
+                            log2File.log(line)
+                        }
+
                         //todo: migrate this to StatusObject, so that we can handle everything properly.
-                        if (logline.getString("level") == "error") {
-                            if (sIsLoggingEnabled) {
-                                log2File?.log(line)
-                            }
+                        if (level == "error") {
                             statusObject.parseLoglineToStatusObject(logline)
-                        } else if (logline.getString("level") == "warning") {
+                        } else if (level == "warning" || logline.has("stats")) {
                             statusObject.parseLoglineToStatusObject(logline)
                         }
 
@@ -211,7 +216,10 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 FLog.e(TAG, "onHandleIntent: error reading stdout", e)
             }
             try {
-                localProcessReference.waitFor()
+                val exitCode = localProcessReference.waitFor()
+                if (exitCode != 0 || statusObject.hasErrors()) {
+                    failureReason = FAILURE_REASON.RCLONE_ERROR
+                }
             } catch (e: InterruptedException) {
                 FLog.e(TAG, "onHandleIntent: error waiting for process", e)
             }
@@ -256,7 +264,11 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
                 content = mContext.getString(R.string.operation_failed_no_connection, mTitle)
             }
             FAILURE_REASON.RCLONE_ERROR -> {
-                content = mContext.getString(R.string.operation_failed_unknown_rclone_error, mTitle)
+                content = if (statusObject.hasErrors()) {
+                    generateCompletedWithErrorsMessage(statusObject)
+                } else {
+                    mContext.getString(R.string.operation_failed_unknown_rclone_error, mTitle)
+                }
             }
         }
         followupTask(mTask.onFailFollowup)
@@ -295,28 +307,56 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
     // this is currently only a useless mapper. It is supposed to keep this worker in sync with the ephemeral one.
     // when they are merged eventually, this can be easily extracted.
     private fun generateSuccessMessage(statusObject: StatusObject): String {
-        var message = mContext.resources.getQuantityString(
-                R.plurals.operation_success_description,
-                statusObject.getTotalTransfers(),
-                mTitle,
-                statusObject.getTotalSize(),
-                statusObject.getTotalTransfers()
+        return SyncResultFormatter.successMessage(statusObject.toResultStats(), resultLabels())
+    }
+
+    private fun generateCompletedWithErrorsMessage(statusObject: StatusObject): String {
+        return SyncResultFormatter.completedWithErrorsMessage(statusObject.toResultStats(), resultLabels())
+    }
+
+    private fun StatusObject.toResultStats(): SyncResultFormatter.Stats {
+        return SyncResultFormatter.Stats(
+            getTotalTransfers(),
+            getTotalSize(),
+            getDeletions(),
+            getRenames(),
+            getErrorCount()
         )
-        if (statusObject.getTotalTransfers() == 0) {
-            message = mContext.resources.getString(R.string.operation_success_description_zero)
-        }
-        if (statusObject.getDeletions() > 0) {
-            message += """
-                        
-                        ${
+    }
+
+    private fun resultLabels(): SyncResultFormatter.Labels {
+        return SyncResultFormatter.Labels(
+            nothingToDo = mContext.getString(R.string.operation_success_description_zero),
+            completedWithErrors = { errors ->
+                mContext.resources.getQuantityString(
+                    R.plurals.operation_completed_with_errors,
+                    errors,
+                    errors
+                )
+            },
+            completed = mContext.getString(R.string.operation_success_description_completed),
+            transferSummary = { totalSize, transfers ->
+                mContext.resources.getQuantityString(
+                    R.plurals.operation_success_description,
+                    transfers,
+                    mTitle,
+                    totalSize,
+                    transfers
+                )
+            },
+            deletionSummary = { deletions ->
                 mContext.getString(
-                        R.string.operation_success_description_deletions_prefix,
-                        statusObject.getDeletions()
+                    R.string.operation_success_description_deletions_prefix,
+                    deletions
+                )
+            },
+            renameSummary = { renames ->
+                mContext.getString(
+                    R.string.operation_success_description_renames_prefix,
+                    renames
                 )
             }
-                        """.trimIndent()
-        }
-        return message
+        )
     }
 
     private fun showFailNotification(notificationId: Int, content: String, wasCancelled: Boolean = false) {

--- a/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
+++ b/app/src/main/java/ca/pkay/rcloneexplorer/workmanager/SyncWorker.kt
@@ -324,6 +324,10 @@ class SyncWorker (private var mContext: Context, workerParams: WorkerParameters)
         )
     }
 
+    /**
+     * Android resource-backed labels for SyncResultFormatter. Keeping these here avoids putting Context
+     * or plural-resource knowledge into the formatter.
+     */
     private fun resultLabels(): SyncResultFormatter.Labels {
         return SyncResultFormatter.Labels(
             nothingToDo = mContext.getString(R.string.operation_success_description_zero),

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -325,9 +325,17 @@
         <item quantity="one">S\'ha suprimit %d fitxer/carpeta.</item>
         <item quantity="other">S\'han suprimit %d fitxers/carpetes.</item>
     </plurals>
+    <plurals name="operation_success_description_deletions_also">
+        <item quantity="one">També s\'ha suprimit %d fitxer/carpeta.</item>
+        <item quantity="other">També s\'han suprimit %d fitxers/carpetes.</item>
+    </plurals>
     <plurals name="operation_success_description_renames">
         <item quantity="one">S\'ha canviat el nom de %d fitxer/carpeta.</item>
         <item quantity="other">S\'ha canviat el nom de %d fitxers/carpetes.</item>
+    </plurals>
+    <plurals name="operation_success_description_renames_also">
+        <item quantity="one">També s\'ha canviat el nom de %d fitxer/carpeta.</item>
+        <item quantity="other">També s\'ha canviat el nom de %d fitxers/carpetes.</item>
     </plurals>
     <string name="operation_report_success_title">Informe de les sincronitzacions reeixides</string>
     <string name="operation_report_success_short_content">%d tasques reeixides</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -312,11 +312,23 @@
     <string name="copy">Copia</string>
     <string name="operation_success">%s sincronitzat amb èxit</string>
     <string name="operation_success_description_zero">No hi ha cap operació pendent.</string>
+    <string name="operation_success_description_completed">Sincronització completada.</string>
+    <plurals name="operation_completed_with_errors">
+        <item quantity="one">Sincronització completada amb %d error.</item>
+        <item quantity="other">Sincronització completada amb %d errors.</item>
+    </plurals>
     <plurals name="operation_success_description">
         <item quantity="one">S\'ha sincronitzat amb èxit %2$s al fitxer %3$d.</item>
         <item quantity="other">S\'han sincronitzat amb èxit %2$s als fitxers %3$d.</item>
     </plurals>
-    <string name="operation_success_description_deletions_prefix">S\'han suprimit també %d fitxers i carpetes.</string>
+    <plurals name="operation_success_description_deletions">
+        <item quantity="one">S\'ha suprimit %d fitxer/carpeta.</item>
+        <item quantity="other">S\'han suprimit %d fitxers/carpetes.</item>
+    </plurals>
+    <plurals name="operation_success_description_renames">
+        <item quantity="one">S\'ha canviat el nom de %d fitxer/carpeta.</item>
+        <item quantity="other">S\'ha canviat el nom de %d fitxers/carpetes.</item>
+    </plurals>
     <string name="operation_report_success_title">Informe de les sincronitzacions reeixides</string>
     <string name="operation_report_success_short_content">%d tasques reeixides</string>
     <string name="operation_report_fail_title">Informe de les fallades en les sincronitzacions</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -313,9 +313,17 @@
         <item quantity="one">%d Datei/Ordner gelöscht.</item>
         <item quantity="other">%d Dateien/Ordner gelöscht.</item>
     </plurals>
+    <plurals name="operation_success_description_deletions_also">
+        <item quantity="one">Außerdem wurde %d Datei/Ordner gelöscht.</item>
+        <item quantity="other">Außerdem wurden %d Dateien/Ordner gelöscht.</item>
+    </plurals>
     <plurals name="operation_success_description_renames">
         <item quantity="one">%d Datei/Ordner umbenannt.</item>
         <item quantity="other">%d Dateien/Ordner umbenannt.</item>
+    </plurals>
+    <plurals name="operation_success_description_renames_also">
+        <item quantity="one">Außerdem wurde %d Datei/Ordner umbenannt.</item>
+        <item quantity="other">Außerdem wurden %d Dateien/Ordner umbenannt.</item>
     </plurals>
     <string name="operation_report_success_title">Sync-Bericht Erfolge</string>
     <string name="operation_report_success_short_content">%d Aufgaben erfolgreich</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -299,13 +299,24 @@
     <string name="sync_direction_copy_remote_local">Kopiere von entferntem Speicher nach lokalem Speicher</string>
     <string name="copy">Kopieren</string>
     <string name="operation_success">%s war erfolgreich</string>
+    <string name="operation_success_description_zero">Es war nichts zu tun.</string>
+    <string name="operation_success_description_completed">Synchronisierung abgeschlossen.</string>
+    <plurals name="operation_completed_with_errors">
+        <item quantity="one">Synchronisierung mit %d Fehler abgeschlossen.</item>
+        <item quantity="other">Synchronisierung mit %d Fehlern abgeschlossen.</item>
+    </plurals>
     <plurals name="operation_success_description">
-        <item quantity="zero">Es gab nichts zu tun.</item>
         <item quantity="one">Es wurden %2$s in %3$d Datei erfolgreich synchronisiert.</item>
         <item quantity="other">Es wurden %2$s in %3$d Dateien erfolgreich synchronisiert.</item>
     </plurals>
-    <string name="operation_success_description_zero">Es war nichts zu tun.</string>
-    <string name="operation_success_description_deletions_prefix">Es wurden ebenfalls %d Dateien und Ordner gelöscht.</string>
+    <plurals name="operation_success_description_deletions">
+        <item quantity="one">%d Datei/Ordner gelöscht.</item>
+        <item quantity="other">%d Dateien/Ordner gelöscht.</item>
+    </plurals>
+    <plurals name="operation_success_description_renames">
+        <item quantity="one">%d Datei/Ordner umbenannt.</item>
+        <item quantity="other">%d Dateien/Ordner umbenannt.</item>
+    </plurals>
     <string name="operation_report_success_title">Sync-Bericht Erfolge</string>
     <string name="operation_report_success_short_content">%d Aufgaben erfolgreich</string>
     <string name="operation_report_fail_title">Sync-Bericht Fehlschläge</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -319,9 +319,17 @@
         <item quantity="one">已删除 %d 个文件/文件夹。</item>
         <item quantity="other">已删除 %d 个文件/文件夹。</item>
     </plurals>
+    <plurals name="operation_success_description_deletions_also">
+        <item quantity="one">还删除了 %d 个文件/文件夹。</item>
+        <item quantity="other">还删除了 %d 个文件/文件夹。</item>
+    </plurals>
     <plurals name="operation_success_description_renames">
         <item quantity="one">已重命名 %d 个文件/文件夹。</item>
         <item quantity="other">已重命名 %d 个文件/文件夹。</item>
+    </plurals>
+    <plurals name="operation_success_description_renames_also">
+        <item quantity="one">还重命名了 %d 个文件/文件夹。</item>
+        <item quantity="other">还重命名了 %d 个文件/文件夹。</item>
     </plurals>
     <string name="operation_report_success_title">Sync-Report 成功</string>
     <string name="operation_report_success_short_content">%d 任务成功</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -306,11 +306,23 @@
     <string name="copy">复制</string>
     <string name="operation_success">%s 同步成功</string>
     <string name="operation_success_description_zero">没什么事可做。</string>
+    <string name="operation_success_description_completed">同步已完成。</string>
+    <plurals name="operation_completed_with_errors">
+        <item quantity="one">同步已完成，但有 %d 个错误。</item>
+        <item quantity="other">同步已完成，但有 %d 个错误。</item>
+    </plurals>
     <plurals name="operation_success_description">
         <item quantity="one">已成功同步 %3$d 文件中的 %2$s。</item>
         <item quantity="other">已成功同步 %3$d 文件中的 %2$s。</item>
     </plurals>
-    <string name="operation_success_description_deletions_prefix">还删除了 %d 个文件和文件夹。</string>
+    <plurals name="operation_success_description_deletions">
+        <item quantity="one">已删除 %d 个文件/文件夹。</item>
+        <item quantity="other">已删除 %d 个文件/文件夹。</item>
+    </plurals>
+    <plurals name="operation_success_description_renames">
+        <item quantity="one">已重命名 %d 个文件/文件夹。</item>
+        <item quantity="other">已重命名 %d 个文件/文件夹。</item>
+    </plurals>
     <string name="operation_report_success_title">Sync-Report 成功</string>
     <string name="operation_report_success_short_content">%d 任务成功</string>
     <string name="operation_report_fail_title">同步报告 - 失败</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -346,8 +346,14 @@
         <item quantity="one">Successfully synced %2$s in %3$d file.</item>
         <item quantity="other">Successfully synced %2$s in %3$d files.</item>
     </plurals>
-    <string name="operation_success_description_deletions_prefix">Also deleted %d files and folders.</string>
-    <string name="operation_success_description_renames_prefix">Also renamed %d files and folders.</string>
+    <plurals name="operation_success_description_deletions">
+        <item quantity="one">Deleted %d file/folder.</item>
+        <item quantity="other">Deleted %d files/folders.</item>
+    </plurals>
+    <plurals name="operation_success_description_renames">
+        <item quantity="one">Renamed %d file/folder.</item>
+        <item quantity="other">Renamed %d files/folders.</item>
+    </plurals>
     <string name="operation_report_success_title">Sync-Report Successes</string>
     <string name="operation_report_success_short_content">%d Tasks succeeded</string>
     <string name="operation_report_fail_title">Sync-Report Failures</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -337,11 +337,17 @@
     <string name="copy">Copy</string>
     <string name="operation_success">%s sync successful</string>
     <string name="operation_success_description_zero">There was nothing to do.</string>
+    <string name="operation_success_description_completed">Sync completed.</string>
+    <plurals name="operation_completed_with_errors">
+        <item quantity="one">Sync completed with %d error.</item>
+        <item quantity="other">Sync completed with %d errors.</item>
+    </plurals>
     <plurals name="operation_success_description">
         <item quantity="one">Successfully synced %2$s in %3$d file.</item>
         <item quantity="other">Successfully synced %2$s in %3$d files.</item>
     </plurals>
     <string name="operation_success_description_deletions_prefix">Also deleted %d files and folders.</string>
+    <string name="operation_success_description_renames_prefix">Also renamed %d files and folders.</string>
     <string name="operation_report_success_title">Sync-Report Successes</string>
     <string name="operation_report_success_short_content">%d Tasks succeeded</string>
     <string name="operation_report_fail_title">Sync-Report Failures</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -350,9 +350,17 @@
         <item quantity="one">Deleted %d file/folder.</item>
         <item quantity="other">Deleted %d files/folders.</item>
     </plurals>
+    <plurals name="operation_success_description_deletions_also">
+        <item quantity="one">Also deleted %d file/folder.</item>
+        <item quantity="other">Also deleted %d files/folders.</item>
+    </plurals>
     <plurals name="operation_success_description_renames">
         <item quantity="one">Renamed %d file/folder.</item>
         <item quantity="other">Renamed %d files/folders.</item>
+    </plurals>
+    <plurals name="operation_success_description_renames_also">
+        <item quantity="one">Also renamed %d file/folder.</item>
+        <item quantity="other">Also renamed %d files/folders.</item>
     </plurals>
     <string name="operation_report_success_title">Sync-Report Successes</string>
     <string name="operation_report_success_short_content">%d Tasks succeeded</string>


### PR DESCRIPTION
Fixes #407

## Summary

This updates sync task result handling so rclone runs that complete with errors are no longer reported as clean successes or as “There was nothing to do”.

The sync result now:
- reports completed-with-errors when final rclone status contains errors
- preserves transfer/deletion/rename summary details even when errors occurred
- only shows “There was nothing to do” when there were no changes and no errors
- avoids duplicating retry-attempt errors in the final notification text
- keeps rclone’s normal safety behavior where destination deletions are skipped after source/listing errors
- persists relevant rclone warning/error log lines from the sync stderr stream
- makes sync notifications open the Logs page
- avoids confusing report notifications by showing only result of the latest task sync in the expanded notification text

